### PR TITLE
経済値、城壁値、駐留数の表示

### DIFF
--- a/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Spot/登場領地.txt
+++ b/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Spot/登場領地.txt
@@ -77,6 +77,9 @@ NewFormatSpot spot0007
 	x = "2600";
 	y = "300";
 	map = "wefwefwefwefw";
+	gain = "50";
+	castle = "5";
+	capacity = "10";
 }
 NewFormatSpot spot0008
 {
@@ -85,6 +88,8 @@ NewFormatSpot spot0008
 	x = "2700";
 	y = "250";
 	map = "wefwefwefwefw";
+	gain = "100";
+	castle = "10";
 	capacity = "12";
 }
 

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
@@ -79,7 +79,7 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 
         // 経済値
         #region Gain
-        private int _gain = 0;
+        private int _gain;
         public int Gain
         {
             get { return _gain; }
@@ -95,7 +95,7 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 
         // 城壁値
         #region Castle
-        private int _castle = 0;
+        private int _castle;
         public int Castle
         {
             get { return _castle; }
@@ -111,7 +111,7 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 
         // 部隊駐留数
         #region Capacity
-        private int _capacity = 0;
+        private int _capacity;
         public int Capacity
         {
             get { return _capacity; }

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
@@ -77,6 +77,36 @@ namespace WPF_Successor_001_to_Vahren._005_Class
         }
         #endregion
 
+        // 経済値
+        #region Gain
+        private int _gain = 0;
+        public int Gain
+        {
+            get { return _gain; }
+            set { _gain = value; }
+        }
+        #endregion
+
+        // 城壁値
+        #region Castle
+        private int _castle = 0;
+        public int Castle
+        {
+            get { return _castle; }
+            set { _castle = value; }
+        }
+        #endregion
+
+        // 部隊駐留数
+        #region Capacity
+        private int _capacity = 0;
+        public int Capacity
+        {
+            get { return _capacity; }
+            set { _capacity = value; }
+        }
+        #endregion
+
         //選択したスポットがどこの勢力に属するかはClassPowerAndCityで見る
 
         #region PowerNameTag

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
@@ -85,6 +85,12 @@ namespace WPF_Successor_001_to_Vahren._005_Class
             get { return _gain; }
             set { _gain = value; }
         }
+        private int _initgain = 0;
+        public int InitGain
+        {
+            get { return _initgain; }
+            set { _initgain = value; }
+        }
         #endregion
 
         // 城壁値
@@ -95,6 +101,12 @@ namespace WPF_Successor_001_to_Vahren._005_Class
             get { return _castle; }
             set { _castle = value; }
         }
+        private int _initcastle = 0;
+        public int InitCastle
+        {
+            get { return _initcastle; }
+            set { _initcastle = value; }
+        }
         #endregion
 
         // 部隊駐留数
@@ -104,6 +116,12 @@ namespace WPF_Successor_001_to_Vahren._005_Class
         {
             get { return _capacity; }
             set { _capacity = value; }
+        }
+        private int _initcapacity = 0;
+        public int InitCapacity
+        {
+            get { return _initcapacity; }
+            set { _initcapacity = value; }
         }
         #endregion
 

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -3379,6 +3379,9 @@ namespace WPF_Successor_001_to_Vahren
 
                 //spot読み込み
                 {
+                    //シナリオで設定されてる標準の駐留数
+                    int default_capacity = this.ListClassScenarioInfo[this.NumberScenarioSelection].SpotCapacity;
+
                     //現シナリオで使用するスポットを抽出する
                     List<ClassSpot> result = new List<ClassSpot>();
                     foreach (var item in this.ListClassScenarioInfo[this.NumberScenarioSelection].DisplayListSpot)
@@ -3387,6 +3390,11 @@ namespace WPF_Successor_001_to_Vahren
                         {
                             if (item == item2.NameTag)
                             {
+                                // 領地の駐留数が指定されてなければ、シナリオ標準値を使う。
+                                if (item2.Capacity < 1)
+                                {
+                                    item2.Capacity = default_capacity;
+                                }
                                 result.Add(item2);
                             }
                         }
@@ -4871,6 +4879,39 @@ namespace WPF_Successor_001_to_Vahren
                     throw new Exception();
                 }
                 classSpot.Y = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+            }
+            //Gain
+            {
+                var match_result =
+                    new Regex(GetPat("gain"), RegexOptions.IgnoreCase)
+                    .Matches(value);
+                var first = CheckMatchElement(match_result);
+                if (first != null)
+                {
+                    classSpot.Gain = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                }
+            }
+            //Castle
+            {
+                var match_result =
+                    new Regex(GetPat("castle"), RegexOptions.IgnoreCase)
+                    .Matches(value);
+                var first = CheckMatchElement(match_result);
+                if (first != null)
+                {
+                    classSpot.Castle = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                }
+            }
+            //Capacity
+            {
+                var match_result =
+                    new Regex(GetPat("capacity"), RegexOptions.IgnoreCase)
+                    .Matches(value);
+                var first = CheckMatchElement(match_result);
+                if (first != null)
+                {
+                    classSpot.Capacity = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                }
             }
             //member
             {

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -597,6 +597,9 @@ namespace WPF_Successor_001_to_Vahren
                     break;
             }
 
+            // シナリオ開始時にデータを初期化する
+            InitializeGameData();
+
             this.ClassGameStatus.Camera = new Point()
             {
                 X = ((-this.CanvasMainWidth) + (this.CanvasMainWidth / 2)),
@@ -3108,6 +3111,33 @@ namespace WPF_Successor_001_to_Vahren
             Thread.Sleep(10);
         }
 
+        // シナリオごとにデータを初期化する関数
+        private void InitializeGameData()
+        {
+            //シナリオで設定されてる標準の駐留数
+            int default_capacity = this.ListClassScenarioInfo[this.NumberScenarioSelection].SpotCapacity;
+
+            // 後から追加するかもしれないので、全ての領地を初期化する
+            foreach (var item in this.ClassGameStatus.AllListSpot)
+            {
+                // とりあえず、初期値をそのまま使う
+                // 将来的には、シナリオによって初期値が違う場合も考慮すること
+                item.Gain = item.InitGain;
+                item.Castle = item.InitCastle;
+
+                // 領地の駐留数が指定されてなければ、シナリオの規定値を使う
+                if (item.InitCapacity < 1)
+                {
+                    item.Capacity = default_capacity;
+                }
+                else
+                {
+                    item.Capacity = item.InitCapacity;
+                }
+            }
+
+        }
+
         private void SetListClassMapBattle(int gameTitleNumber)
         {
             // get target path.
@@ -3379,9 +3409,6 @@ namespace WPF_Successor_001_to_Vahren
 
                 //spot読み込み
                 {
-                    //シナリオで設定されてる標準の駐留数
-                    int default_capacity = this.ListClassScenarioInfo[this.NumberScenarioSelection].SpotCapacity;
-
                     //現シナリオで使用するスポットを抽出する
                     List<ClassSpot> result = new List<ClassSpot>();
                     foreach (var item in this.ListClassScenarioInfo[this.NumberScenarioSelection].DisplayListSpot)
@@ -3390,11 +3417,6 @@ namespace WPF_Successor_001_to_Vahren
                         {
                             if (item == item2.NameTag)
                             {
-                                // 領地の駐留数が指定されてなければ、シナリオ標準値を使う。
-                                if (item2.Capacity < 1)
-                                {
-                                    item2.Capacity = default_capacity;
-                                }
                                 result.Add(item2);
                             }
                         }
@@ -4888,7 +4910,7 @@ namespace WPF_Successor_001_to_Vahren
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.Gain = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.InitGain = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //Castle
@@ -4899,7 +4921,7 @@ namespace WPF_Successor_001_to_Vahren
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.Castle = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.InitCastle = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //Capacity
@@ -4910,7 +4932,7 @@ namespace WPF_Successor_001_to_Vahren
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.Capacity = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.InitCapacity = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //member

--- a/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
@@ -27,7 +27,7 @@
 
         <StackPanel Orientation="Horizontal" Margin="10,100,0,0">
             <Label FontSize="20" Foreground="White" Content="経済" />
-            <Label FontSize="20" Foreground="White" Content="1000" Name="lblIncome" />
+            <Label FontSize="20" Foreground="White" Content="1000" Name="lblGain" />
             <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="城壁" />
             <Label FontSize="20" Foreground="White" Content="50" Name="lblCastle" />
             <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="戦力" />
@@ -35,6 +35,11 @@
             <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="部隊" />
             <Label FontSize="20" Foreground="White" Content="16/16" Name="lblMemberCount" />
         </StackPanel>
+
+        <ScrollViewer Width="460" Height="440" Canvas.Left="10" Canvas.Top="150" Background="Black" >
+            <StackPanel>
+            </StackPanel>
+        </ScrollViewer>
 
     </Canvas>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml.cs
@@ -40,6 +40,7 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             var classPowerAndCity = (ClassPowerAndCity)this.Tag;
+            int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
 
             //旗は存在する時だけ
             if (classPowerAndCity.ClassPower.FlagPath != string.Empty)
@@ -59,6 +60,25 @@ namespace WPF_Successor_001_to_Vahren
                 //this.lblNameSpot.Content = this.Name; // ウインドウ番号を表示する実験用
                 this.lblNameSpot.Content = classPowerAndCity.ClassSpot.Name;
             }
+            //経済値
+            {
+                this.lblGain.Content = classPowerAndCity.ClassSpot.Gain;
+            }
+            //城壁値
+            {
+                this.lblCastle.Content = classPowerAndCity.ClassSpot.Castle;
+            }
+            //部隊駐留数
+            {
+                int count = mainWindow.ClassGameStatus.AllListSpot
+                    .Where(x => x.NameTag == classPowerAndCity.ClassSpot.NameTag)
+                    .First()
+                    .UnitGroup
+                    .Where(x => x.Spot.NameTag == classPowerAndCity.ClassSpot.NameTag)
+                    .Count();
+                this.lblMemberCount.Content = count.ToString() + "/" + spot_capacity.ToString();
+            }
+
 
             // 最前面に配置する
             try


### PR DESCRIPTION
spot構造体に gain, castle, capacity が指定されてる場合は
その値を読み込むようにしました。

spot構造体に capacity が指定されてなければ、
scenario構造体の spot_capacity を規定値として流用します。

領地ウインドウで経済値、城壁値、駐留数を表示するようにしました。