### PR TITLE
ユニットをドラッグする実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
@@ -40,9 +40,10 @@
                 MouseLeftButtonUp="Raise_ZOrder"
                 MouseRightButtonUp="Disable_MouseEvent"
                 >
-            <Canvas Name="canvasSpotUnit" Width="400" Height="500" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Gray">
+            <Canvas Name="canvasSpotUnit" HorizontalAlignment="Left" VerticalAlignment="Top">
 
 <!--
+            <Canvas Name="canvasSpotUnit" Width="400" Height="500" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Gray">
                 <StackPanel Orientation="Horizontal" Height="68">
                     <StackPanel>
                         <Button Height="30" Margin="2" FontSize="15" Content="出撃" />


### PR DESCRIPTION
領地上のユニットをドラッグする実験です。
まだドロップ部分は作ってないので、
ユニットの配置を変更することはできません。
あくまで、操作方法をテストしてます。
ドラッグできるのは部隊のメンバーだけです。
リーダーはまだです。

ドロップ先を水色で強調してます。
ヴァーレンは実際にマウスでホバーした時だけ強調してるんですが、
それだとどこにドロップできるかが分かりにくいので、
常に強調表示するようにしてみました。
ドロップ処理との兼ね合いで、更に変更する予定です。

ドラッグ中にマウスへ吸い付く画像なんですが、
ボタン全体を動かすか、ユニット画像だけを動かすか、
どちらでも実装可能です。
UserControl006_Spot.xaml.csの
unit_MouseRightButtonDown関数において、
コメントアウトする箇所を変えると、画像を変更できます。