### PR TITLE
ユニットをドラッグする実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -1130,17 +1130,11 @@ namespace WPF_Successor_001_to_Vahren
                         itemChild.Margin = posWindow;
 
                         // 最前面に移動する
-                        try
+                        var listWindow = this.canvasUI.Children.OfType<UIElement>().Where(x => x != itemChild);
+                        if ( (listWindow != null) && (listWindow.Any()) )
                         {
-                            int maxZ = this.canvasUI.Children.OfType<UIElement>()
-                               .Where(x => x != itemChild)
-                               .Select(x => Canvas.GetZIndex(x))
-                               .Max();
+                            int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
                             Canvas.SetZIndex(itemChild, maxZ + 1);
-                        }
-                        catch (InvalidOperationException)
-                        {
-                            // 比較する子ウインドウがなければそのまま
                         }
 
                         window_id = find_id;


### PR DESCRIPTION
子ウインドウを最前面に移動させる際に、
他の子ウインドウが無ければ何もしないようにしました。

領地ウインドウ上のユニットをドラッグする実験です。
部隊の部下ユニットだけ、同じ領地上でドラッグ＆ドロップできるようになりました。
ドラッグ中に動かす画像が大きいと、ドロップ先が見えなくなる問題に気付きました。
改善方法はこれから考えます。
とりあえず、ドラッグ＆ドロップの挙動はうまくいってるようです。