### PR TITLE
全部ボタンで領地の全部隊をドラッグ移動

### DIFF
--- a/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl006_Spot.xaml
@@ -18,9 +18,16 @@
         <Button x:Name="btnClose" Width="35" Height="35" Margin="435,10,0,0" Padding="0,-6,0,0" FontSize="30" Click="btnClose_Click">×</Button>
 
         <StackPanel Orientation="Horizontal" Margin="10,60,0,0">
-            <Button x:Name="btnSelectAll" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="全部" />
-            <Button x:Name="btnMercenary" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用" />
-            <Button x:Name="btnPolitics" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="内政" />
+            <Button x:Name="btnSelectAll" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="全部"
+                    PreviewMouseDown="whole_MouseDown"
+                    MouseRightButtonUp="Disable_MouseEvent"
+                    />
+            <Button x:Name="btnMercenary" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用"
+                    MouseRightButtonUp="Disable_MouseEvent"
+                    />
+            <Button x:Name="btnPolitics" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="内政"
+                    MouseRightButtonUp="Disable_MouseEvent"
+                    />
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="10,100,0,0">


### PR DESCRIPTION
「全部ボタン」を押す（マウスの左右どちらでも）ことで、
領地の全部隊をドラッグ移動できるようになりました。

ドラッグ中は、各部隊の隊長ユニットの画像だけ縦に並べて表示します。
１部隊をドラッグする場合は横に並ぶので、違いが分かりやすいかも。

ドロップ先の空きが少ない場合は、先頭の部隊から順に移動させていきます。
なので、全ての部隊が動くとは限りません。
ヴァーレンでは警告メッセージがでるけど、個人的に鬱陶しく思ってたので、
余計なメッセージは出してません。