### PR TITLE
領地の強調表示など

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml
@@ -10,7 +10,7 @@
         ContentRendered="MainWindow_ContentRendered"
         KeyDown="MainWindow_KeyDown" 
         Closing="MainWindow_Closing"
-        Height="900"
+        Height="1024"
         Width="1600"
         MinHeight="600"
         MinWidth="800"
@@ -18,18 +18,18 @@
         Left="0"
         >
     <Canvas x:Name="canvasTop" Opacity="1" Background="Transparent" SizeChanged="canvasTop_SizeChanged">
-        <Canvas x:Name="canvasUIRightTop"
-                Panel.ZIndex="99"
+        <Canvas x:Name="canvasUIRightBottom"
+                Panel.ZIndex="97"
                 Width="{Binding canvasMainWidth}"
                 Height="{Binding canvasMainHeight}">
         </Canvas>
-        <Canvas x:Name="canvasUIRightBottom"
-                Panel.ZIndex="99"
+        <Canvas x:Name="canvasUIRightTop"
+                Panel.ZIndex="98"
                 Width="{Binding canvasMainWidth}"
                 Height="{Binding canvasMainHeight}">
         </Canvas>
         <Canvas x:Name="canvasUI"
-                Panel.ZIndex="100"
+                Panel.ZIndex="99"
                 Width="{Binding canvasMainWidth}"
                 Height="{Binding canvasMainHeight}">
         </Canvas>

--- a/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml
@@ -9,45 +9,45 @@
       >
     <Border Background="#454545" BorderBrush="Black" BorderThickness="5">
         <Canvas>
-            <Image Stretch="Fill" Margin="0,6,0,0" Height="32" Width="32" Name="imgFlag"></Image>
-            <Label Width="250" Height="40" FontSize="23" Margin="34,0,0,0" Foreground="White" Content="test" Name="lblNamePower"></Label>
+            <Image Canvas.Left="5" Canvas.Top="5" Height="32" Width="32" Name="imgFlag"/>
+            <TextBlock Height="35" Canvas.Left="45" Canvas.Top="5" FontSize="23" Foreground="White" Text="test" Name="txtNamePower"/>
             <ScrollViewer Width="189" Height="290" Canvas.Top="40" HorizontalAlignment="Center" VerticalAlignment="Top">
                 <StackPanel>
                     <Canvas Height="30">
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="軍資金"></Label>
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="75,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="9999999" Name="lblNameMoney"></Label>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="軍資金"/>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="75,0,0,0" Foreground="White" TextAlignment="Right" Text="9999999" Name="txtMoney"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="総収入"></Label>
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="75,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="9999999" Name="lblNameTotalGain"></Label>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="総収入"/>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="75,0,0,0" Foreground="White" TextAlignment="Right" Text="9999999" Name="txtTotalGain"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="収入補正"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="+5%" Name="lblNameGainCorrection"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="収入補正"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="+5%" Name="txtGainCorrection"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="領地数"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameNumberSpot"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="領地数"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtNumberSpot"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="ユニット数"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameNumberUnit"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="ユニット数"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtNumberUnit"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="維持費"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameMaintenanceCosts"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="維持費"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtTotalCost"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="財政値"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameNumberFinance"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="財政値"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtTotalFinance"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="訓練値"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameNumberTraining"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="訓練値"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtNumberTraining"/>
                     </Canvas>
                     <Canvas Height="30">
-                        <Label Width="90" Height="30" Padding="-5" FontSize="20" Margin="5,0,0,0" Foreground="White" Content="影響力"></Label>
-                        <Label Width="70" Height="30" Padding="-5" FontSize="20" Margin="95,0,0,0" Foreground="White" HorizontalContentAlignment="Right" Content="999" Name="lblNameInfluence"></Label>
+                        <TextBlock Width="90" Height="30" FontSize="20" Margin="5,0,0,0" Foreground="White" Text="影響力"/>
+                        <TextBlock Width="70" Height="30" FontSize="20" Margin="95,0,0,0" Foreground="White" TextAlignment="Right" Text="999" Name="txtInfluence"/>
                     </Canvas>
                 </StackPanel>
             </ScrollViewer>
@@ -63,20 +63,20 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="2" Grid.RowSpan="2" x:Name="btnTurnEnd" Click="btnTurnEnd_Click" Margin="0,0,2,2">
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="2" Grid.RowSpan="2" x:Name="btnTurnEnd" Click="btnTurnEnd_Click" Focusable="False" Margin="0,0,2,2">
                     <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="28"/>
                     </Grid.RowDefinitions>
-                        <Border Grid.Row="0" Height="100" Width="100" Background="#454545" BorderBrush="White" BorderThickness="2">
-                            <Image Height="96" Width="96" Stretch="Fill" Name="imgFace"/>
+                        <Border Grid.Row="0" BorderBrush="#29acca" BorderThickness="3">
+                            <Image Height="96" Width="96" Name="imgFace"/>
                         </Border>
                         <Label Grid.Row="1" Padding="4" HorizontalAlignment="Left" VerticalAlignment="Bottom" Foreground="#575757" Background="#F1F2F7" BorderBrush="#767676" BorderThickness="1" Content="ターン終了" />
                     </Grid>
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="0" Margin="0,0,2,2" Background="Transparent" ToolTip="人材雇用">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f91d;" /><!--手をつなぐ人-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="0" Focusable="False" Margin="0,0,2,2" ToolTip="人材雇用">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f91d;" /><!--手をつなぐ人-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -98,8 +98,8 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="1" Margin="0,0,2,2" Background="Transparent" ToolTip="カード確認">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f0cf;" /><!--ジョーカー-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="1" Focusable="False" Margin="0,0,2,2" ToolTip="カード確認">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f0cf;" /><!--ジョーカー-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -148,8 +148,8 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="2" Margin="0,0,2,2" Background="Transparent" ToolTip="外交">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f5e8;" /><!--左向きの吹き出し-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="2" Focusable="False" Margin="0,0,2,2" ToolTip="外交">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f5e8;" /><!--左向きの吹き出し-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -179,8 +179,8 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="3" Margin="0,0,2,2" Background="Transparent" ToolTip="ターン委任">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f502;" /><!--1回リピート-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="0" Grid.Row="3" Focusable="False" Margin="0,0,2,2" ToolTip="ターン委任">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f502;" /><!--1回リピート-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -236,8 +236,8 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="2" Margin="0,0,2,2" Background="Transparent" ToolTip="静観" >
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x267E;" /><!--無限-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="2" Focusable="False" Margin="0,0,2,2" ToolTip="静観" >
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x267E;" /><!--無限-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -246,8 +246,8 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="3" Margin="0,0,2,2" Background="Transparent" ToolTip="機能">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x2699;" /><!--ギア-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="1" Grid.Row="3" Focusable="False" Margin="0,0,2,2" ToolTip="機能">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x2699;" /><!--ギア-->
 <!--
                     <Canvas>
                         <Ellipse Height="55" Stroke="Black" Fill="Black" Width="55" Canvas.Left="-27.5" Canvas.Top="-27.5">
@@ -286,11 +286,11 @@
                     </Canvas>
 -->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="2" Grid.Row="2" Margin="0,0,2,2" Background="Transparent" ToolTip="市場">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f3f0;" /><!--西洋の城-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="2" Grid.Row="2" Focusable="False" Margin="0,0,2,2" ToolTip="市場">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f3f0;" /><!--西洋の城-->
                 </Button>
-                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="2" Grid.Row="3" Margin="0,0,2,2" Background="Transparent" ToolTip="探索">
-                    <Label Foreground="White" Padding="-10" FontSize="36" Content="&#x1f575;" /><!--探偵-->
+                <Button BorderBrush="Black" BorderThickness="4" Grid.Column="2" Grid.Row="3" Focusable="False" Margin="0,0,2,2" ToolTip="探索">
+                    <TextBlock Foreground="#29acca" FontSize="36" Text="&#x1f575;" /><!--探偵-->
                 </Button>
             </Grid>
         </Canvas>

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             Height="690" Width="480"
-             >
+             Height="690" Width="480">
     <Canvas
             MouseLeftButtonDown="win_MouseLeftButtonDown"
             MouseRightButtonUp="btnClose_Click"
@@ -14,36 +13,36 @@
         <Border Height="690" Width="480" Background="#454545" BorderBrush="Black" BorderThickness="5" />
 
         <Border Height="44" Width="420" BorderBrush="White" BorderThickness="2" Canvas.Left="8" Canvas.Top="8" />
-        <Image Stretch="Fill" Canvas.Left="14" Canvas.Top="14" Height="32" Width="32" Name="imgFlag" />
-        <Label Width="375" Canvas.Left="50" Canvas.Top="10" FontSize="23" Foreground="White" Content="領地の名前" Name="lblNameSpot" />
+        <Image Canvas.Left="14" Canvas.Top="14" Height="32" Width="32" Name="imgFlag" />
+        <TextBlock Canvas.Left="55" Canvas.Top="15" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
 
-        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="435" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Click="btnClose_Click">×</Button>
+        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="435" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
         <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="60">
-            <Button x:Name="btnSelectAll" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="全部"
+            <Button x:Name="btnSelectAll" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="全部"
                     PreviewMouseDown="whole_MouseDown"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />
-            <Button x:Name="btnMercenary" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用"
+            <Button x:Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="雇用"
                     Click="btnMercenary_Click"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />
-            <Button x:Name="btnPolitics" Width="70" Height="35" Margin="0,0,5,0" FontSize="20" Content="内政"
+            <Button x:Name="btnPolitics" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="内政"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="100">
-            <Label FontSize="20" Foreground="White" Content="経済" />
-            <Label FontSize="20" Foreground="White" Content="1000" Name="lblGain" />
-            <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="城壁" />
-            <Label FontSize="20" Foreground="White" Content="50" Name="lblCastle" />
-            <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="戦力" />
-            <Label FontSize="20" Foreground="White" Content="123456" Name="lblForce" />
-            <Label FontSize="20" Margin="10,0,0,0" Foreground="White" Content="部隊" />
-            <Label FontSize="20" Foreground="White" Content="16/16" Name="lblMemberCount" />
+        <StackPanel Orientation="Horizontal" Canvas.Left="15" Canvas.Top="105">
+            <TextBlock FontSize="20" Foreground="White" Text="経済" />
+            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="1000" Name="txtGain" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="城壁" />
+            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="50" Name="txtCastle" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="戦力" />
+            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="123456" Name="txtForce" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="部隊" />
+            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="16/16" Name="txtTroopCount" />
         </StackPanel>
 
         <ScrollViewer Width="460" Height="535" Canvas.Left="10" Canvas.Top="145" Background="#262626"
@@ -67,7 +66,7 @@
                     </StackPanel>
                     <StackPanel>
                         <Image Height="48" Width="48" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
-                        <Label Padding="-5" Height="18" FontSize="15" Foreground="White" HorizontalAlignment="Center" Content="lv199E" />
+                        <TextBlock Height="18" FontSize="15" Foreground="White" TextAlignment="Center" Text="lv199E" />
                     </StackPanel>
                     <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
                     <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -38,7 +38,15 @@ namespace WPF_Successor_001_to_Vahren
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
             {
-            	return;
+                return;
+            }
+
+            // 最前面に配置する
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ( (listWindow != null) && (listWindow.Any()) )
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
             }
 
             // プレイヤーが操作可能かどうか
@@ -54,14 +62,6 @@ namespace WPF_Successor_001_to_Vahren
 
             // 領地の情報を表示する
             DisplaySpotStatus(mainWindow);
-
-            // 最前面に配置する
-            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
-            if ( (listWindow != null) && (listWindow.Any()) )
-            {
-                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
-                Canvas.SetZIndex(this, maxZ + 1);
-            }
         }
 
         // 領地のユニットを変更した際に、ユニット表示だけを更新する
@@ -98,6 +98,7 @@ namespace WPF_Successor_001_to_Vahren
                             btnSelect.Height = tile_height / 2 - 4;
                             btnSelect.Width = header_width - 4;
                             btnSelect.Margin = new Thickness(2);
+                            btnSelect.Focusable = false;
                             btnSelect.FontSize = 15;
                             btnSelect.Content = "出撃";
                             this.canvasSpotUnit.Children.Add(btnSelect);
@@ -109,6 +110,7 @@ namespace WPF_Successor_001_to_Vahren
                             cmbFormation.Height = tile_height / 2 - 4;
                             cmbFormation.Width = header_width - 4;
                             cmbFormation.Margin = new Thickness(2);
+                            cmbFormation.Focusable = false;
                             // _010_Enum.Formation の順番に表示するので、Enum数値と Index は同じになる
                             cmbFormation.Items.Add(_010_Enum.Formation.F.ToString());
                             cmbFormation.Items.Add(_010_Enum.Formation.M.ToString());
@@ -122,15 +124,17 @@ namespace WPF_Successor_001_to_Vahren
                         else
                         {
                             // 操作できない場合は、陣形だけ表示する
-                            Label label = new Label();
-                            label.Background = SystemColors.WindowBrush;
-                            label.Width = 30;
-                            label.Height = 30;
-                            label.Margin = new Thickness(10, 20, 0, 0);
-                            label.FontSize = 15;
-                            label.Content = itemUnit.Formation.Formation;
-                            this.canvasSpotUnit.Children.Add(label);
-                            Canvas.SetTop(label, tile_height * i);
+                            Label lblFormation = new Label();
+                            lblFormation.Background = SystemColors.WindowBrush;
+                            lblFormation.Width = 30;
+                            lblFormation.Height = 30;
+                            lblFormation.Margin = new Thickness(10, 20, 0, 0);
+                            lblFormation.FontSize = 15;
+                            lblFormation.HorizontalContentAlignment = HorizontalAlignment.Center;
+                            lblFormation.VerticalContentAlignment = VerticalAlignment.Center;
+                            lblFormation.Content = itemUnit.Formation.Formation.ToString();
+                            this.canvasSpotUnit.Children.Add(lblFormation);
+                            Canvas.SetTop(lblFormation, tile_height * i);
                         }
                     }
 
@@ -173,15 +177,14 @@ namespace WPF_Successor_001_to_Vahren
                     panelUnit.Children.Add(imgUnit);
 
                     // ユニットのレベル
-                    Label lblLevel = new Label();
-                    lblLevel.Name = "lblLevel" + i.ToString() + "_" + j.ToString();
-                    lblLevel.Height = tile_height - tile_width;
-                    lblLevel.FontSize = 15;
-                    lblLevel.Padding = new Thickness(-5);
-                    lblLevel.Foreground = Brushes.White;
-                    lblLevel.HorizontalAlignment = HorizontalAlignment.Center;
-                    lblLevel.Content = "lv" + itemUnit.Level;
-                    panelUnit.Children.Add(lblLevel);
+                    TextBlock txtLevel = new TextBlock();
+                    txtLevel.Name = "txtLevel" + i.ToString() + "_" + j.ToString();
+                    txtLevel.Height = tile_height - tile_width;
+                    txtLevel.FontSize = 15;
+                    txtLevel.Foreground = Brushes.White;
+                    txtLevel.TextAlignment = TextAlignment.Center;
+                    txtLevel.Text = "lv" + itemUnit.Level;
+                    panelUnit.Children.Add(txtLevel);
 
                     this.canvasSpotUnit.Children.Add(panelUnit);
                     Canvas.SetLeft(panelUnit, header_width + tile_width * j);
@@ -202,7 +205,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // 部隊数も更新する
             int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
-            this.lblMemberCount.Content = i.ToString() + "/" + spot_capacity.ToString();
+            this.txtTroopCount.Text = i.ToString() + "/" + spot_capacity.ToString();
 
             // ユニット配置場所の大きさ
             if (_isControl)
@@ -254,19 +257,19 @@ namespace WPF_Successor_001_to_Vahren
             }
             //領地名
             {
-                this.lblNameSpot.Content = classPowerAndCity.ClassSpot.Name;
+                this.txtNameSpot.Text = classPowerAndCity.ClassSpot.Name;
             }
             //経済値
             {
-                this.lblGain.Content = classPowerAndCity.ClassSpot.Gain;
+                this.txtGain.Text = classPowerAndCity.ClassSpot.Gain.ToString();
             }
             //城壁値
             {
-                this.lblCastle.Content = classPowerAndCity.ClassSpot.Castle;
+                this.txtCastle.Text = classPowerAndCity.ClassSpot.Castle.ToString();
             }
             //戦力値
             {
-                this.lblForce.Content = this.Name.Replace("dowSpot", String.Empty); // ウインドウ番号を表示する実験用
+                this.txtForce.Text = this.Name.Replace("dowSpot", String.Empty); // ウインドウ番号を表示する実験用
             }
             //部隊駐留数
             {
@@ -277,7 +280,7 @@ namespace WPF_Successor_001_to_Vahren
                     .UnitGroup
                     .Where(x => x.Spot.NameTag == classPowerAndCity.ClassSpot.NameTag)
                     .Count();
-                this.lblMemberCount.Content = count.ToString() + "/" + spot_capacity.ToString();
+                this.txtTroopCount.Text = count.ToString() + "/" + spot_capacity.ToString();
             }
             //ユニット
             {

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl011_SpotHint"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
+             mc:Ignorable="d" 
+             Height="360" Width="400">
+    <Canvas IsHitTestVisible="False">
+        <Border Height="360" Width="400" Background="#454545" BorderBrush="Black" BorderThickness="5" Opacity="0.5" />
+        <TextBlock Canvas.Left="10" Canvas.Top="10" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
+
+
+    </Canvas>
+</UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using WPF_Successor_001_to_Vahren._005_Class;
+
+namespace WPF_Successor_001_to_Vahren
+{
+    /// <summary>
+    /// UserControl011_SpotHint.xaml の相互作用ロジック
+    /// </summary>
+    public partial class UserControl011_SpotHint : UserControl
+    {
+        public UserControl011_SpotHint()
+        {
+            InitializeComponent();
+        }
+
+        public void SetData()
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            var classPowerAndCity = (ClassPowerAndCity)this.Tag;
+            if (classPowerAndCity == null)
+            {
+                return;
+            }
+            if (classPowerAndCity.ClassSpot == null)
+            {
+                return;
+            }
+
+            // 最前面に配置する
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ( (listWindow != null) && (listWindow.Any()) )
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
+            }
+
+            //領地名
+            this.txtNameSpot.Text = classPowerAndCity.ClassSpot.Name;
+
+
+        }
+
+    }
+}

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
@@ -15,64 +15,64 @@
         <Image Canvas.Left="15" Canvas.Top="15" Height="32" Width="32" Name="imgUnit" />
 
         <Image Stretch="Fill" Canvas.Left="483" Canvas.Top="33" Height="32" Width="32" Name="imgFlag" />
-        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="525" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Click="btnClose_Click">×</Button>
+        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="525" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
         <Image Canvas.Left="460" Canvas.Top="530" Height="96" Width="96" Name="imgFace" />
 
-        <StackPanel Canvas.Left="90" Canvas.Top="5" Width="390">
-            <StackPanel Orientation="Horizontal" Height="45" HorizontalAlignment="Center">
-                <Label Padding="-5" FontSize="23" Foreground="White" VerticalContentAlignment="Center" Content="ユニットの名前" Name="lblNameUnit" />
-                <Label Padding="-5" FontSize="20" Foreground="#C8FFC8" VerticalContentAlignment="Center" Content="（種族名）" Name="lblRace" />
+        <StackPanel Canvas.Left="90" Canvas.Top="10" Width="390">
+            <StackPanel Orientation="Horizontal" Height="40" HorizontalAlignment="Center">
+                <TextBlock Margin="0,2" FontSize="23" Foreground="White" Text="ユニットの名前" Name="txtNameUnit" />
+                <TextBlock Margin="0,4" FontSize="20" Foreground="#C8FFC8" Text="（種族名）" Name="txtRace" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center">
-                <Label Padding="-5" FontSize="20" Foreground="White" Content="レベルとクラス名" Name="lblLevelClass" />
-                <Label Padding="-5" FontSize="20" Content="（性別）" Name="lblSex" />
+                <TextBlock FontSize="20" Foreground="White" Text="レベルとクラス名" Name="txtLevelClass" />
+                <TextBlock FontSize="20" Text="（性別）" Name="txtSex" />
             </StackPanel>
-            <Label Height="30" Padding="-5" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Center" Content="経験値 FontSize=18" Name="lblExp" />
-            <Label Height="25" Padding="-5" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Center" Content="戦功値 999999" Name="lblMerits" />
+            <TextBlock Height="30" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Center" Text="経験値 FontSize=18" Name="txtExp" />
+            <TextBlock Height="25" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Center" Text="戦功値 999999" Name="txtMerits" />
         </StackPanel>
 
         <StackPanel Canvas.Left="15" Canvas.Top="85">
-            <Label Height="30" Padding="-5" FontSize="18" Foreground="#FFC800" Content="身分" Name="lblRank" />
-            <Label Height="25" Padding="-5" FontSize="18" Foreground="#FFFF00" Content="信用度・忠誠" Name="lblLoyal" />
+            <TextBlock Height="30" FontSize="18" Foreground="#FFC800" Text="身分" Name="txtRank" />
+            <TextBlock Height="25" FontSize="18" Foreground="#FFFF00" Text="信用度・忠誠" Name="txtLoyal" />
         </StackPanel>
         <StackPanel Canvas.Left="355" Canvas.Top="85" Width="200">
-            <Label Height="30" Padding="-5" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Right" Content="所持金 10485769" Name="lblMoney" />
-            <Label Height="25" Padding="-5" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Right" Content="維持費 999999" Name="lblCost" />
+            <TextBlock Height="30" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Right" Text="所持金 10485769" Name="txtMoney" />
+            <TextBlock Height="25" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Right" Text="維持費 999999" Name="txtCost" />
         </StackPanel>
 
         <Border Canvas.Left="10" Canvas.Top="150" Height="435" Width="265" BorderBrush="White" BorderThickness="2" />
         <StackPanel Canvas.Left="15" Canvas.Top="160" Width="85">
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="移動型" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="HP" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="MP" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="攻撃" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="防御" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="魔力" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="魔抵抗" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="素早さ" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="技術" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="HP回復" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="MP回復" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="移動力" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="召喚" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="財政力" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="移動型" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="HP" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="MP" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="攻撃" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="防御" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="魔力" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="魔抵抗" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="素早さ" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="技術" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="HP回復" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="MP回復" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="移動力" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="召喚" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="財政力" />
         </StackPanel>
-        <StackPanel Canvas.Left="95" Canvas.Top="160" Width="165">
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="FontSize=20" Name="lblMoveType" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="9999999/9999999" Name="lblHP" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="99999/99999" Name="lblMP" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblAttack" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblDefense" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblMagic" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblMagDef" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblSpeed" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblDext" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblHPRec" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="99/99" Name="lblMPRec" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="999/999" Name="lblMove" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Right" Content="99/99" Name="lblSummon" />
-            <Label Height="30" Padding="-5" FontSize="20" Foreground="#FFC800" HorizontalAlignment="Right" Content="9999" Name="lblFinance" />
+        <StackPanel Canvas.Left="100" Canvas.Top="160" Width="162">
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="FontSize=20" Name="txtMoveType" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="9999999/9999999" Name="txtHP" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="99999/99999" Name="txtMP" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtAttack" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtDefense" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtMagic" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtMagDef" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtSpeed" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtDext" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtHPRec" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="99/99" Name="txtMPRec" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="999/999" Name="txtMove" />
+            <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="99/99" Name="txtSummon" />
+            <TextBlock Height="30" FontSize="20" Foreground="#FFC800" TextAlignment="Right" Text="9999" Name="txtFinance" />
         </StackPanel>
 
         <WrapPanel Canvas.Left="285" Canvas.Top="150" Width="272" Orientation="Horizontal" ItemHeight="34" ItemWidth="34" Name="panelSkill">
@@ -89,22 +89,22 @@
         </WrapPanel>
 
         <StackPanel Canvas.Left="285" Canvas.Top="320">
-            <Label Height="20" Padding="-5" FontSize="16" Content="耐性は FontSize=16" />
-            <Label Height="20" Padding="-5" FontSize="16" Content="なんたらに強い" />
-            <Label Height="20" Padding="-5" FontSize="16" Content="かんたらに弱い" />
+            <TextBlock Height="20" FontSize="16" Text="耐性は FontSize=16" />
+            <TextBlock Height="20" FontSize="16" Text="なんたらに強い" />
+            <TextBlock Height="20" FontSize="16" Text="かんたらに弱い" />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Canvas.Left="15" Canvas.Top="595">
-            <Button x:Name="btnDismiss" Width="80" Height="35" Margin="0,0,5,0" FontSize="20" Content="解雇"
+        <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="595">
+            <Button x:Name="btnDismiss" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="解雇"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />
-            <Button x:Name="btnMercenary" Width="80" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用"
+            <Button x:Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="雇用"
                     Click="btnMercenary_Click"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />
-            <Button x:Name="btnItem" Width="80" Height="35" Margin="0,0,5,0" FontSize="20" Content="アイテム"
+            <Button x:Name="btnItem" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="アイテム"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
                     />

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
@@ -33,7 +33,7 @@ namespace WPF_Successor_001_to_Vahren
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
             {
-            	return;
+                return;
             }
 
             ClassCityAndUnit classCityAndUnit = (ClassCityAndUnit)this.Tag;
@@ -160,16 +160,16 @@ namespace WPF_Successor_001_to_Vahren
 
             // ユニット名
             {
-                this.lblNameUnit.Content = targetUnit.Name;
+                this.txtNameUnit.Text = targetUnit.Name;
             }
             // 種族
             if (targetUnit.Race != string.Empty){
-                this.lblRace.Content = "（" + targetUnit.Race + "）";
+                this.txtRace.Text = "（" + targetUnit.Race + "）";
             }
             // レベルとクラス
             {
-                //this.lblClass.Content = this.Name; // ウインドウ番号を表示する実験用
-                this.lblLevelClass.Content = "Lv" + targetUnit.Level.ToString() + " " + targetUnit.Class;
+                //this.txtClass.Text = this.Name; // ウインドウ番号を表示する実験用
+                this.txtLevelClass.Text = "Lv" + targetUnit.Level.ToString() + " " + targetUnit.Class;
             }
 
             // 経験値
@@ -181,20 +181,39 @@ namespace WPF_Successor_001_to_Vahren
                     required_exp = targetUnit.Exp + required_exp * targetUnit.Exp_mul / 100;
                     level_up--;
                 }
-                this.lblExp.Content = "EXP 0/" + required_exp.ToString();
+                this.txtExp.Text = "EXP 0/" + required_exp.ToString();
             }
             // 戦功値
+            if ( (targetPower.NameTag == string.Empty) || (targetUnit.NameTag == targetPower.MasterTag) )
             {
-                this.lblMerits.Content = "Member = " + member_id + "/" + member_count; // メンバー番号を表示する実験用
+                // 中立ユニットやマスターは戦功値を表示しない
+                this.txtMerits.Text = string.Empty;
+            }
+            else
+            {
+                this.txtMerits.Text = "Member = " + member_id.ToString() + "/" + member_count; // メンバー番号を表示する実験用
             }
 
             // 所持金
             {
-                this.lblMoney.Content = "ID = " + targetUnit.ID; // ユニット番号を表示する実験用
+                this.txtMoney.Text = "ID = " + targetUnit.ID.ToString(); // ユニット番号を表示する実験用
             }
             // 維持費
+            if (targetUnit.NameTag == targetPower.MasterTag)
             {
-                this.lblCost.Content = "維持費 " + targetUnit.Cost.ToString();
+                // マスターは維持費がかからない
+                this.txtCost.Text = string.Empty;
+            }
+            else
+            {
+                int actual_cost = targetUnit.Cost;
+                if (actual_cost < 0)
+                {
+                    // 維持費がマイナスの場合はゼロと表示する
+                    actual_cost = 0;
+                }
+                // 身分によって維持費が変動することに注意
+                this.txtCost.Text = "維持費 " + actual_cost.ToString();
             }
 
             // 人材の時だけ項目を表示する
@@ -203,38 +222,47 @@ namespace WPF_Successor_001_to_Vahren
                 // マスターなら忠誠ではなく信用度を表示する
                 if (targetUnit.NameTag == targetPower.MasterTag)
                 {
-                    this.lblRank.Content = "マスター";
-                    this.lblLoyal.Content = "信用度 ?";
+                    this.txtRank.Text = "マスター";
+                    this.txtLoyal.Text = "信用度 ?";
                 }
                 else
                 {
-                    this.lblRank.Content = "一般";
-                    this.lblLoyal.Content = "忠誠 " + targetUnit.Loyal.ToString();
+                    this.txtRank.Text = "一般";
+                    this.txtLoyal.Text = "忠誠 " + targetUnit.Loyal.ToString();
                 }
             }
             else
             {
                 // 一般兵は表示しない
-                this.lblRank.Content = string.Empty;
-                this.lblLoyal.Content = string.Empty;
+                this.txtRank.Text = string.Empty;
+                this.txtLoyal.Text = string.Empty;
             }
 
             // 能力値
             {
-                this.lblMoveType.Content = targetUnit.MoveType;
-                this.lblHP.Content = targetUnit.Hp.ToString() + "/" + targetUnit.Hp.ToString();
-                this.lblMP.Content = targetUnit.Mp.ToString() + "/" + targetUnit.Mp.ToString();
-                this.lblAttack.Content = targetUnit.Attack.ToString() + "/" + targetUnit.Attack.ToString();
-                this.lblDefense.Content = targetUnit.Defense.ToString() + "/" + targetUnit.Defense.ToString();
-                this.lblMagic.Content = targetUnit.Magic.ToString() + "/" + targetUnit.Magic.ToString();
-                this.lblMagDef.Content = targetUnit.MagDef.ToString() + "/" + targetUnit.MagDef.ToString();
-                this.lblSpeed.Content = targetUnit.Speed.ToString() + "/" + targetUnit.Speed.ToString();
-                this.lblDext.Content = targetUnit.Dext.ToString() + "/" + targetUnit.Dext.ToString();
-                this.lblHPRec.Content = targetUnit.Hprec.ToString() + "/" + targetUnit.Hprec.ToString();
-                this.lblMPRec.Content = targetUnit.Mprec.ToString() + "/" + targetUnit.Mprec.ToString();
-                this.lblMove.Content = targetUnit.Move.ToString() + "/" + targetUnit.Move.ToString();
-                this.lblSummon.Content = targetUnit.Summon_max.ToString() + "/" + targetUnit.Summon_max.ToString();
-                this.lblFinance.Content = targetUnit.Finance.ToString();
+                this.txtMoveType.Text = targetUnit.MoveType;
+
+                // スキルで増減した補正値と、本来の値の２種類を表示する
+                this.txtHP.Text = targetUnit.Hp.ToString() + "/" + targetUnit.Hp.ToString();
+                this.txtMP.Text = targetUnit.Mp.ToString() + "/" + targetUnit.Mp.ToString();
+                this.txtAttack.Text = targetUnit.Attack.ToString() + "/" + targetUnit.Attack.ToString();
+                this.txtDefense.Text = targetUnit.Defense.ToString() + "/" + targetUnit.Defense.ToString();
+                this.txtMagic.Text = targetUnit.Magic.ToString() + "/" + targetUnit.Magic.ToString();
+                this.txtMagDef.Text = targetUnit.MagDef.ToString() + "/" + targetUnit.MagDef.ToString();
+                this.txtSpeed.Text = targetUnit.Speed.ToString() + "/" + targetUnit.Speed.ToString();
+                this.txtDext.Text = targetUnit.Dext.ToString() + "/" + targetUnit.Dext.ToString();
+                this.txtHPRec.Text = targetUnit.Hprec.ToString() + "/" + targetUnit.Hprec.ToString();
+                this.txtMPRec.Text = targetUnit.Mprec.ToString() + "/" + targetUnit.Mprec.ToString();
+                this.txtMove.Text = targetUnit.Move.ToString() + "/" + targetUnit.Move.ToString();
+                this.txtSummon.Text = targetUnit.Summon_max.ToString() + "/" + targetUnit.Summon_max.ToString();
+
+                // 維持費がマイナスなら財政値になる
+                int actual_finance = targetUnit.Finance;
+                if (targetUnit.Cost < 0)
+                {
+                    actual_finance -= targetUnit.Cost;
+                }
+                this.txtFinance.Text = actual_finance.ToString();
             }
         }
 

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
@@ -12,9 +12,9 @@
             >
         <Border Name="borderWindow" Height="515" Width="360" Background="#454545" BorderBrush="Black" BorderThickness="5" />
 
-        <Label Width="310" Canvas.Left="5" Canvas.Top="10" HorizontalContentAlignment="Center" FontSize="23" Foreground="White" Content="タイトル" Name="lblTitle" />
+        <TextBlock Width="310" Canvas.Left="5" Canvas.Top="15" TextAlignment="Center" FontSize="23" Foreground="White" Text="タイトル" Name="txtTitle" />
 
-        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="315" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Click="btnClose_Click">×</Button>
+        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="315" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
         <ScrollViewer Name="scrollList" Width="340" Height="448" Canvas.Left="10" Canvas.Top="57" Background="#262626"
                 VerticalScrollBarVisibility="Auto"
@@ -36,8 +36,8 @@
                     <Button Grid.RowSpan="2" Height="52" Width="52">
                         <Image Height="32" Width="32" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene001.png" />
                     </Button>
-                    <Label Grid.Column="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="戦列歩兵M14式" />
-                    <Label Grid.Column="1" Grid.Row="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="金100" />
+                    <TextBlock Grid.Column="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="戦列歩兵M14式" />
+                    <TextBlock Grid.Column="1" Grid.Row="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="金100" />
                 </Grid>
 
                 <Grid Height="56" Margin="5,4,0,4">
@@ -52,8 +52,8 @@
                     <Button Grid.RowSpan="2" Height="52" Width="52">
                         <Image Height="32" Width="32" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene002.png" />
                     </Button>
-                    <Label Grid.Column="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="榴弾砲C11式" />
-                    <Label Grid.Column="1" Grid.Row="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="金10000" />
+                    <TextBlock Grid.Column="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="榴弾砲C11式" />
+                    <TextBlock Grid.Column="1" Grid.Row="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="金10000" />
                 </Grid>
 
                 <Grid Height="56" Margin="5,4,0,4">
@@ -68,8 +68,8 @@
                     <Button Grid.RowSpan="2" Height="52" Width="52">
                         <Image Height="32" Width="32" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
                     </Button>
-                    <Label Grid.Column="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="フランチェスカ竜騎兵" />
-                    <Label Grid.Column="1" Grid.Row="1" Padding="-5" FontSize="20" Foreground="White" HorizontalAlignment="Center" Content="金1000" />
+                    <TextBlock Grid.Column="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="フランチェスカ竜騎兵" />
+                    <TextBlock Grid.Column="1" Grid.Row="1" FontSize="20" Foreground="White" HorizontalAlignment="Center" Text="金1000" />
                 </Grid>
 -->
 

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -36,7 +36,7 @@ namespace WPF_Successor_001_to_Vahren
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
             {
-            	return;
+                return;
             }
 
             // ユニットの情報を表示する
@@ -62,7 +62,7 @@ namespace WPF_Successor_001_to_Vahren
             // タイトル
             if (targetSpot == null)
             {
-                this.lblTitle.Content = this.Name; // ウインドウ番号を表示する実験用
+                this.txtTitle.Text = this.Name; // ウインドウ番号を表示する実験用
 
                 // targetSpot は必ず指定しないといけない
                 return;
@@ -70,12 +70,12 @@ namespace WPF_Successor_001_to_Vahren
             else if (targetUnit == null)
             {
                 // targetUnit が null なら領地の雇用とみなす
-                this.lblTitle.Content = targetSpot.Name + "で雇用";
+                this.txtTitle.Text = targetSpot.Name + "で雇用";
             }
             else
             {
                 // targetSpot に居る targetUnit による雇用とみなす
-                this.lblTitle.Content = targetUnit.Name + "の雇用";
+                this.txtTitle.Text = targetUnit.Name + "の雇用";
             }
 
             // 雇用可能なユニットのリストを初期化する
@@ -149,6 +149,7 @@ namespace WPF_Successor_001_to_Vahren
                 //btnUnit.Background = Brushes.Transparent;
                 btnUnit.Width = btn_width;
                 btnUnit.Height = btn_height;
+                btnUnit.Focusable = false;
                 btnUnit.Content = imgUnit;
                 btnUnit.Click += btnUnit_Click;
                 btnUnit.MouseRightButtonDown += btnUnit_MouseRightButtonDown;
@@ -156,27 +157,25 @@ namespace WPF_Successor_001_to_Vahren
                 gridItem.Children.Add(btnUnit);
 
                 // 名前
-                Label lblName = new Label();
-                lblName.Name = "lblName" + item_count.ToString();
-                lblName.FontSize = 20;
-                lblName.Padding = new Thickness(-5);
-                lblName.Foreground = Brushes.White;
-                lblName.HorizontalAlignment = HorizontalAlignment.Center;
-                lblName.Content = itemBaseUnit.Name;
-                Grid.SetColumn(lblName, 1);
-                gridItem.Children.Add(lblName);
+                TextBlock txtName = new TextBlock();
+                txtName.Name = "txtName" + item_count.ToString();
+                txtName.FontSize = 20;
+                txtName.Foreground = Brushes.White;
+                txtName.HorizontalAlignment = HorizontalAlignment.Center;
+                txtName.Text = itemBaseUnit.Name;
+                Grid.SetColumn(txtName, 1);
+                gridItem.Children.Add(txtName);
 
                 // 金額
-                Label lblPrice = new Label();
-                lblPrice.Name = "lblPrice" + item_count.ToString();
-                lblPrice.FontSize = 20;
-                lblPrice.Padding = new Thickness(-5);
-                lblPrice.Foreground = Brushes.White;
-                lblPrice.HorizontalAlignment = HorizontalAlignment.Center;
-                lblPrice.Content = "金" + itemBaseUnit.Price;
-                Grid.SetColumn(lblPrice, 1);
-                Grid.SetRow(lblPrice, 1);
-                gridItem.Children.Add(lblPrice);
+                TextBlock txtPrice = new TextBlock();
+                txtPrice.Name = "txtPrice" + item_count.ToString();
+                txtPrice.FontSize = 20;
+                txtPrice.Foreground = Brushes.White;
+                txtPrice.HorizontalAlignment = HorizontalAlignment.Center;
+                txtPrice.Text = "金" + itemBaseUnit.Price.ToString();
+                Grid.SetColumn(txtPrice, 1);
+                Grid.SetRow(txtPrice, 1);
+                gridItem.Children.Add(txtPrice);
 
                 this.panelList.Children.Add(gridItem);
                 item_count++;
@@ -341,7 +340,7 @@ namespace WPF_Successor_001_to_Vahren
             // 雇用するユニットの元データ
             var btnUnit = (Button)sender;
             ClassUnit baseUnit = (ClassUnit)btnUnit.Tag;
-            //this.lblTitle.Content = baseUnit.Name + "を一人雇う"; // 実験用
+            //this.txtTitle.Text = baseUnit.Name + "を一人雇う"; // 実験用
 
             // 金が足りなかったらダメ
             if (targetPower.Money < baseUnit.Price)
@@ -551,7 +550,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 add_count--;
             }
-            //this.lblTitle.Content = baseUnit.Name + "を" + add_count + "人雇う"; // 実験用
+            //this.txtTitle.Text = baseUnit.Name + "を" + add_count + "人雇う"; // 実験用
 
             // 資金を減らす
             targetPower.Money -= baseUnit.Price * add_count;

--- a/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
+++ b/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
@@ -10,6 +10,9 @@
     <Compile Update="UserControl010_Spot.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="UserControl011_SpotHint.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="UserControl015_Unit.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -22,6 +25,9 @@
   </ItemGroup>
   <ItemGroup>
     <Page Update="UserControl010_Spot.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl011_SpotHint.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl015_Unit.xaml">


### PR DESCRIPTION
Label よりも TextBlock の方が速いらしいので、
文字だけなら TextBlock を使うように変更しました。

Label は数値を自動的に文字列に変換してくれるけど、
TextBlock だと自分で変換してからセットすることになります。
Label の HorizontalContentAlignment は
TextBlock だと TextAlignment になります。
TextBlock の文字配置は、
Label で Padding="-5" するのと同じ位置になるようです。

垂直方向の位置を設定したい時は、Label じゃないと駄目でした。
BorderThicknessプロパティで枠を付けたい時は、Label じゃないと駄目でした。

DropShadowEffect で文字に影を付けるようにしました。

Button や ComboBox に Focusable="False" をセットしとかないと
Tab キーで選択されてしまうことに気付いたので、修正しました。

戦略マップ上の領地アイコンにマウス・カーソルを乗せると、
同じ勢力の領地を強調するようにしました。

戦略マップ上の領地アイコンを少し前面に出しました。

勢力メニューのボタンの色を変えました。

ターン数を表示するようにしました。