### PR TITLE
領地のヒントを表示

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -1528,45 +1528,29 @@ namespace WPF_Successor_001_to_Vahren
             this.ClassGameStatus.SelectionPowerAndCity = ((ClassPowerAndCity)((Button)sender).Tag);
             foreach (var itemSpot in this.ClassGameStatus.AllListSpot)
             {
-                itemSpot.UnitGroup = new List<ClassHorizontalUnit>();
-                //メンバー配置
-                foreach (var itemMember in itemSpot.ListMember)
+                // 中立領地にモンスターをランダム配置する（初期メンバーが指定されてる場合は除外する）
+                if ( (itemSpot.PowerNameTag == string.Empty) && (itemSpot.UnitGroup.Count() == 0) )
                 {
-                    var info = this.ClassGameStatus.ListUnit.Where(x => x.NameTag == itemMember.Item1).FirstOrDefault();
-                    if (info == null)
+                    // ListWanderingMonster と ListMonster の仕様が不明なので、元のままにしておく。
+                    // ヴァーレンだと、指定された比率と制限に準じて、部隊数とメンバー数をランダムに決める。
+                    foreach (var ListWanderingMonster in itemSpot.ListWanderingMonster)
                     {
-                        continue;
-                    }
+                        var info = this.ClassGameStatus.ListUnit.Where(x => x.NameTag == ListWanderingMonster.Item1).FirstOrDefault();
+                        if (info == null)
+                        {
+                            continue;
+                        }
+                        var classUnit = new List<ClassUnit>();
+                        for (int i = 0; i < ListWanderingMonster.Item2; i++)
+                        {
+                            var deep = info.DeepCopy();
+                            deep.ID = this.ClassGameStatus.IDCount;
+                            this.ClassGameStatus.SetIDCount();
+                            classUnit.Add(deep);
+                        }
 
-                    var classUnit = new List<ClassUnit>();
-                    for (int i = 0; i < itemMember.Item2; i++)
-                    {
-                        var deep = info.DeepCopy();
-                        deep.ID = this.ClassGameStatus.IDCount;
-                        this.ClassGameStatus.SetIDCount();
-                        classUnit.Add(deep);
+                        itemSpot.UnitGroup.Add(new ClassHorizontalUnit() { Spot = itemSpot, FlagDisplay = true, ListClassUnit = classUnit });
                     }
-
-                    itemSpot.UnitGroup.Add(new ClassHorizontalUnit() { Spot = itemSpot, FlagDisplay = true, ListClassUnit = classUnit });
-                }
-                //中立配置
-                foreach (var ListWanderingMonster in itemSpot.ListWanderingMonster)
-                {
-                    var info = this.ClassGameStatus.ListUnit.Where(x => x.NameTag == ListWanderingMonster.Item1).FirstOrDefault();
-                    if (info == null)
-                    {
-                        continue;
-                    }
-                    var classUnit = new List<ClassUnit>();
-                    for (int i = 0; i < ListWanderingMonster.Item2; i++)
-                    {
-                        var deep = info.DeepCopy();
-                        deep.ID = this.ClassGameStatus.IDCount;
-                        this.ClassGameStatus.SetIDCount();
-                        classUnit.Add(deep);
-                    }
-
-                    itemSpot.UnitGroup.Add(new ClassHorizontalUnit() { Spot = itemSpot, FlagDisplay = true, ListClassUnit = classUnit });
                 }
             }
 
@@ -3533,6 +3517,33 @@ namespace WPF_Successor_001_to_Vahren
 
                 canvas.Children.Add(grid);
                 this.canvasMain.Children.Add(canvas);
+            }
+
+            // 領地に初期メンバーを配置する（中立領地のランダムモンスターは勢力選択後）
+            foreach (var itemSpot in this.ClassGameStatus.AllListSpot)
+            {
+                itemSpot.UnitGroup = new List<ClassHorizontalUnit>();
+
+                // 初期メンバー配置（中立領地でも指定されていれば配置する）
+                foreach (var itemMember in itemSpot.ListMember)
+                {
+                    var info = this.ClassGameStatus.ListUnit.Where(x => x.NameTag == itemMember.Item1).FirstOrDefault();
+                    if (info == null)
+                    {
+                        continue;
+                    }
+
+                    var classUnit = new List<ClassUnit>();
+                    for (int i = 0; i < itemMember.Item2; i++)
+                    {
+                        var deep = info.DeepCopy();
+                        deep.ID = this.ClassGameStatus.IDCount;
+                        this.ClassGameStatus.SetIDCount();
+                        classUnit.Add(deep);
+                    }
+
+                    itemSpot.UnitGroup.Add(new ClassHorizontalUnit() { Spot = itemSpot, FlagDisplay = true, ListClassUnit = classUnit });
+                }
             }
 
             // 勢力一覧ウィンドウを出す

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
@@ -5,12 +5,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             Height="690" Width="480">
+             Height="680" Width="480">
     <Canvas
             MouseLeftButtonDown="win_MouseLeftButtonDown"
             MouseRightButtonUp="btnClose_Click"
             >
-        <Border Height="690" Width="480" Background="#454545" BorderBrush="Black" BorderThickness="5" />
+        <Border Height="680" Width="480" Background="#454545" BorderBrush="Black" BorderThickness="5" />
 
         <Border Height="44" Width="420" BorderBrush="White" BorderThickness="2" Canvas.Left="8" Canvas.Top="8" />
         <Image Canvas.Left="14" Canvas.Top="14" Height="32" Width="32" Name="imgFlag" />
@@ -34,18 +34,14 @@
                     />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Canvas.Left="15" Canvas.Top="105">
-            <TextBlock FontSize="20" Foreground="White" Text="経済" />
-            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="1000" Name="txtGain" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="城壁" />
-            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="50" Name="txtCastle" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="戦力" />
-            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="123456" Name="txtForce" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="White" Text="部隊" />
-            <TextBlock FontSize="20" Margin="5,0,0,0" Foreground="White" Text="16/16" Name="txtTroopCount" />
+        <StackPanel Orientation="Horizontal" Canvas.Left="15" Canvas.Top="100">
+            <TextBlock FontSize="20" Foreground="Aqua" Text="経済 1000" Name="txtGain" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="城壁 150" Name="txtCastle" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="戦力 1234567" Name="txtForce" />
+            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="部隊 16/16" Name="txtTroopCount" />
         </StackPanel>
 
-        <ScrollViewer Width="460" Height="535" Canvas.Left="10" Canvas.Top="145" Background="#262626"
+        <ScrollViewer Width="460" Height="535" Canvas.Left="10" Canvas.Top="135" Background="#262626"
                 HorizontalScrollBarVisibility="Auto"
                 VerticalScrollBarVisibility="Visible"
                 PreviewMouseLeftButtonDown="Raise_ZOrder"
@@ -54,19 +50,18 @@
             <Canvas Name="canvasSpotUnit" HorizontalAlignment="Left" VerticalAlignment="Top">
 
 <!--
-            <Canvas Name="canvasSpotUnit" Width="400" Height="500" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Gray">
                 <StackPanel Orientation="Horizontal" Height="66">
                     <StackPanel>
-                        <Button Height="29" Margin="2" FontSize="15" Content="出撃" />
-                        <ComboBox Width="44" Height="29" Margin="2" FontSize="15">
-                            <ComboBoxItem Content="F" Background="Red" Foreground="White" />
-                            <ComboBoxItem Content="M" Background="Green" Foreground="White" />
-                            <ComboBoxItem Content="B" Background="Blue" Foreground="White" />
+                        <Button Height="29" Margin="2" FontSize="17" Content="出撃" />
+                        <ComboBox Width="44" Height="29" Margin="2" FontSize="17">
+                            <ComboBoxItem Content="F"/>
+                            <ComboBoxItem Content="M"/>
+                            <ComboBoxItem Content="B"/>
                         </ComboBox>
                     </StackPanel>
                     <StackPanel>
                         <Image Height="48" Width="48" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
-                        <TextBlock Height="18" FontSize="15" Foreground="White" TextAlignment="Center" Text="lv199E" />
+                        <TextBlock Height="18" FontSize="16" Foreground="White" TextAlignment="Center" Text="lv199E" />
                     </StackPanel>
                     <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
                     <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -29,7 +29,7 @@ namespace WPF_Successor_001_to_Vahren
 
         // 定数
         // ユニットのタイルサイズをここで調節できます
-        private const int tile_width = 48, tile_height = 66, header_width = 48;
+        private const int tile_width = 48, tile_height = 66, header_width = 54;
 
         // 最初に呼び出した時
         private bool _isControl = false; // 操作可能かどうかの設定
@@ -99,7 +99,7 @@ namespace WPF_Successor_001_to_Vahren
                             btnSelect.Width = header_width - 4;
                             btnSelect.Margin = new Thickness(2);
                             btnSelect.Focusable = false;
-                            btnSelect.FontSize = 15;
+                            btnSelect.FontSize = 17;
                             btnSelect.Content = "出撃";
                             this.canvasSpotUnit.Children.Add(btnSelect);
                             Canvas.SetTop(btnSelect, tile_height * i);
@@ -111,11 +111,45 @@ namespace WPF_Successor_001_to_Vahren
                             cmbFormation.Width = header_width - 4;
                             cmbFormation.Margin = new Thickness(2);
                             cmbFormation.Focusable = false;
+
                             // _010_Enum.Formation の順番に表示するので、Enum数値と Index は同じになる
-                            cmbFormation.Items.Add(_010_Enum.Formation.F.ToString());
-                            cmbFormation.Items.Add(_010_Enum.Formation.M.ToString());
-                            cmbFormation.Items.Add(_010_Enum.Formation.B.ToString());
-                            cmbFormation.FontSize = 15;
+                            // 項目ごとに背景色を変える
+                            Label lblItem0 = new Label();
+                            lblItem0.Content = _010_Enum.Formation.F.ToString();
+                            lblItem0.FontSize = 17;
+                            lblItem0.HorizontalContentAlignment = HorizontalAlignment.Center;
+                            lblItem0.Padding = new Thickness(-5);
+                            lblItem0.Width = header_width - 32;
+                            lblItem0.Background = Brushes.Maroon; // RGB=128,0,0
+                            lblItem0.Foreground = Brushes.White;
+                            ComboBoxItem cbItem0 = new ComboBoxItem();
+                            cbItem0.Content = lblItem0;
+                            cmbFormation.Items.Add(cbItem0);
+
+                            Label lblItem1 = new Label();
+                            lblItem1.Content = _010_Enum.Formation.M.ToString();
+                            lblItem1.FontSize = 17;
+                            lblItem1.HorizontalContentAlignment = HorizontalAlignment.Center;
+                            lblItem1.Padding = new Thickness(-5);
+                            lblItem1.Width = header_width - 32;
+                            lblItem1.Background = Brushes.DarkGreen; // RGB=0,100,0
+                            lblItem1.Foreground = Brushes.White;
+                            ComboBoxItem cbItem1 = new ComboBoxItem();
+                            cbItem1.Content = lblItem1;
+                            cmbFormation.Items.Add(cbItem1);
+
+                            Label lblItem2 = new Label();
+                            lblItem2.Content = _010_Enum.Formation.B.ToString();
+                            lblItem2.FontSize = 17;
+                            lblItem2.HorizontalContentAlignment = HorizontalAlignment.Center;
+                            lblItem2.Padding = new Thickness(-5);
+                            lblItem2.Width = header_width - 32;
+                            lblItem2.Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 160));
+                            lblItem2.Foreground = Brushes.White;
+                            ComboBoxItem cbItem2 = new ComboBoxItem();
+                            cbItem2.Content = lblItem2;
+                            cmbFormation.Items.Add(cbItem2);
+
                             cmbFormation.SelectedIndex = (int)itemUnit.Formation.Formation;
                             cmbFormation.SelectionChanged += cmbFormation_SelectionChanged;
                             this.canvasSpotUnit.Children.Add(cmbFormation);
@@ -125,11 +159,25 @@ namespace WPF_Successor_001_to_Vahren
                         {
                             // 操作できない場合は、陣形だけ表示する
                             Label lblFormation = new Label();
-                            lblFormation.Background = SystemColors.WindowBrush;
-                            lblFormation.Width = 30;
-                            lblFormation.Height = 30;
-                            lblFormation.Margin = new Thickness(10, 20, 0, 0);
-                            lblFormation.FontSize = 15;
+                            lblFormation.Foreground = Brushes.White;
+                            // 項目ごとに背景色を変える
+                            if ((int)itemUnit.Formation.Formation == 0)
+                            {
+                                lblFormation.Background = Brushes.Maroon;
+                            }
+                            else if ((int)itemUnit.Formation.Formation == 1)
+                            {
+                                lblFormation.Background = Brushes.DarkGreen;
+                            }
+                            else
+                            {
+                                lblFormation.Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 160));
+                            }
+                            lblFormation.Width = tile_height / 2 - 4;
+                            lblFormation.Height = tile_height / 2 - 4;
+                            lblFormation.Margin = new Thickness((header_width - lblFormation.Width) / 2, (tile_height - lblFormation.Height) / 2, 0, 0);
+                            lblFormation.FontSize = 17;
+                            lblFormation.Padding = new Thickness(-5);
                             lblFormation.HorizontalContentAlignment = HorizontalAlignment.Center;
                             lblFormation.VerticalContentAlignment = VerticalAlignment.Center;
                             lblFormation.Content = itemUnit.Formation.Formation.ToString();
@@ -180,7 +228,7 @@ namespace WPF_Successor_001_to_Vahren
                     TextBlock txtLevel = new TextBlock();
                     txtLevel.Name = "txtLevel" + i.ToString() + "_" + j.ToString();
                     txtLevel.Height = tile_height - tile_width;
-                    txtLevel.FontSize = 15;
+                    txtLevel.FontSize = 16;
                     txtLevel.Foreground = Brushes.White;
                     txtLevel.TextAlignment = TextAlignment.Center;
                     txtLevel.Text = "lv" + itemUnit.Level;
@@ -205,7 +253,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // 部隊数も更新する
             int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
-            this.txtTroopCount.Text = i.ToString() + "/" + spot_capacity.ToString();
+            this.txtTroopCount.Text = "部隊 " + i.ToString() + "/" + spot_capacity.ToString();
 
             // ユニット配置場所の大きさ
             if (_isControl)
@@ -242,7 +290,7 @@ namespace WPF_Successor_001_to_Vahren
             // まだ処理を作ってないのでボタンを無効にする
             btnPolitics.IsEnabled = false;
 
-            //旗は存在する時だけ
+            // 旗は存在する時だけ
             if (classPowerAndCity.ClassPower.FlagPath != string.Empty)
             {
                 List<string> strings = new List<string>();
@@ -255,34 +303,29 @@ namespace WPF_Successor_001_to_Vahren
                 var destimg = new CroppedBitmap(bitimg1, rect);
                 this.imgFlag.Source = destimg;
             }
-            //領地名
+            // 領地名
             {
                 this.txtNameSpot.Text = classPowerAndCity.ClassSpot.Name;
             }
-            //経済値
+            // 経済値
             {
-                this.txtGain.Text = classPowerAndCity.ClassSpot.Gain.ToString();
+                this.txtGain.Text = "経済 " + classPowerAndCity.ClassSpot.Gain.ToString();
             }
-            //城壁値
+            // 城壁値
             {
-                this.txtCastle.Text = classPowerAndCity.ClassSpot.Castle.ToString();
+                this.txtCastle.Text = "城壁 " + classPowerAndCity.ClassSpot.Castle.ToString();
             }
-            //戦力値
+            // 戦力値
             {
-                this.txtForce.Text = this.Name.Replace("dowSpot", String.Empty); // ウインドウ番号を表示する実験用
+                this.txtForce.Text = "戦力 " + this.Name.Replace("dowSpot", String.Empty); // ウインドウ番号を表示する実験用
             }
-            //部隊駐留数
+            // 部隊駐留数
             {
                 int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
-                int count = mainWindow.ClassGameStatus.AllListSpot
-                    .Where(x => x.NameTag == classPowerAndCity.ClassSpot.NameTag)
-                    .First()
-                    .UnitGroup
-                    .Where(x => x.Spot.NameTag == classPowerAndCity.ClassSpot.NameTag)
-                    .Count();
-                this.txtTroopCount.Text = count.ToString() + "/" + spot_capacity.ToString();
+                int troop_count = classPowerAndCity.ClassSpot.UnitGroup.Count();
+                this.txtTroopCount.Text = "部隊 " + troop_count.ToString() + "/" + spot_capacity.ToString();
             }
-            //ユニット
+            // ユニット
             {
                 UpdateSpotUnit(mainWindow);
             }

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
@@ -5,11 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             Height="360" Width="400">
+             Height="100" Width="400">
     <Canvas IsHitTestVisible="False">
-        <Border Height="360" Width="400" Background="#454545" BorderBrush="Black" BorderThickness="5" Opacity="0.5" />
-        <TextBlock Canvas.Left="10" Canvas.Top="10" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
+        <Border Name="borderWindow" Height="100" Width="400" Background="#454545" BorderBrush="Black" BorderThickness="5" Opacity="0.5"/>
 
+        <TextBlock Canvas.Left="10" Canvas.Top="10" FontSize="19" Foreground="Aqua" Text="勢力の名前" Name="txtNamePower"/>
+        <TextBlock Canvas.Left="10" Canvas.Top="35" FontSize="19" Foreground="White" Text="領地の名前" Name="txtNameSpot"/>
+        <TextBlock Canvas.Left="10" Canvas.Top="60" FontSize="19" Foreground="Yellow" Text="経済1500 城壁290 部隊10/16 戦力1237567" Name="txtStatus"/>
 
+        <StackPanel Canvas.Left="10" Canvas.Top="85" Name="panelSpotUnit"/>
     </Canvas>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
@@ -52,9 +52,104 @@ namespace WPF_Successor_001_to_Vahren
                 Canvas.SetZIndex(this, maxZ + 1);
             }
 
-            //領地名
+            // 勢力名
+            if (classPowerAndCity.ClassPower.NameTag != string.Empty)
+            {
+                this.txtNamePower.Text = classPowerAndCity.ClassPower.Name;
+            }
+            else
+            {
+                this.txtNamePower.Text = "中立勢力";
+            }
+
+            // 領地名
             this.txtNameSpot.Text = classPowerAndCity.ClassSpot.Name;
 
+            // 部隊数を数えてユニットを表示する
+            int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
+            int tile_height = 32, tile_width = 32;
+            var listTroop = classPowerAndCity.ClassSpot.UnitGroup;
+            int troop_count = listTroop.Count();
+            int member_max = 0;
+            if (troop_count > 0)
+            {
+                // 画像のディレクトリ
+                List<string> strings = new List<string>();
+                strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+                strings.Add("040_ChipImage");
+                string pathDirectory = System.IO.Path.Combine(strings.ToArray()) + System.IO.Path.DirectorySeparatorChar;
+
+                // 部隊数によって画像サイズを変える
+                // ８部隊、８人、までなら32ドット。それを超えると画像が途切れる。
+                tile_height = 256 / troop_count;
+                if (tile_height > 32)
+                {
+                    tile_height = 32;
+                }
+                else if (tile_height < 16)
+                {
+                    tile_height = 16;
+                }
+                int member_capacity = mainWindow.ListClassScenarioInfo[mainWindow.NumberScenarioSelection].MemberCapacity;
+                tile_width = 384 / member_capacity;
+                if (tile_width > 32)
+                {
+                    tile_width = 32;
+                }
+                else if (tile_width < 16)
+                {
+                    tile_width = 16;
+                }
+
+                // ユニットを並べる
+                int j;
+                foreach (var itemTroop in listTroop)
+                {
+                    // 部隊のパネル
+                    StackPanel panelTroop = new StackPanel();
+                    panelTroop.Orientation = Orientation.Horizontal;
+                    panelTroop.Height = tile_height;
+
+                    j = 0;
+                    foreach (var itemUnit in itemTroop.ListClassUnit)
+                    {
+                        // ユニットの画像
+                        BitmapImage bitimg1 = new BitmapImage(new Uri(pathDirectory + itemUnit.Image));
+                        Int32Rect rect = new Int32Rect(0, 0, tile_width, tile_height);
+                        var destimg = new CroppedBitmap(bitimg1, rect);
+
+                        Image imgUnit = new Image();
+                        imgUnit.Source = destimg;
+                        imgUnit.Width = tile_width;
+                        imgUnit.Height = tile_height;
+                        panelTroop.Children.Add(imgUnit);
+
+                        j++;
+                    }
+                    if (member_max < j)
+                    {
+                        member_max = j;
+                    }
+
+                    this.panelSpotUnit.Children.Add(panelTroop);
+                }
+            }
+
+            // 経済、城壁、部隊、戦力
+            this.txtStatus.Text = "経済" + classPowerAndCity.ClassSpot.Gain.ToString()
+                                + " 城壁" + classPowerAndCity.ClassSpot.Castle.ToString()
+                                + " 部隊" + troop_count.ToString() + "/" + spot_capacity.ToString()
+                                + " 戦力 ?";
+
+            // ウインドウの大きさを調節する
+            if (troop_count > 0)
+            {
+                this.borderWindow.Height = 85 + tile_height * troop_count + 10;
+            }
+            if (10 + tile_width * member_max + 10 > 400)
+            {
+                this.borderWindow.Height = 10 + tile_width * member_max + 10;
+            }
 
         }
 

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
@@ -5,12 +5,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             Height="640" Width="570">
+             Height="630" Width="570">
     <Canvas
             MouseLeftButtonDown="win_MouseLeftButtonDown"
             MouseRightButtonUp="btnClose_Click"
             >
-        <Border Height="640" Width="570" Background="#454545" BorderBrush="Black" BorderThickness="5" />
+        <Border Height="630" Width="570" Background="#454545" BorderBrush="Black" BorderThickness="5" />
 
         <Image Canvas.Left="15" Canvas.Top="15" Height="32" Width="32" Name="imgUnit" />
 
@@ -20,29 +20,29 @@
         <Image Canvas.Left="460" Canvas.Top="530" Height="96" Width="96" Name="imgFace" />
 
         <StackPanel Canvas.Left="90" Canvas.Top="10" Width="390">
-            <StackPanel Orientation="Horizontal" Height="40" HorizontalAlignment="Center">
-                <TextBlock Margin="0,2" FontSize="23" Foreground="White" Text="ユニットの名前" Name="txtNameUnit" />
-                <TextBlock Margin="0,4" FontSize="20" Foreground="#C8FFC8" Text="（種族名）" Name="txtRace" />
+            <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center">
+                <TextBlock FontSize="23" Foreground="White" Text="ユニットの名前" Name="txtNameUnit" />
+                <TextBlock Margin="0,2" FontSize="20" Foreground="#C8FFC8" Text="（種族名）" Name="txtRace" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center">
                 <TextBlock FontSize="20" Foreground="White" Text="レベルとクラス名" Name="txtLevelClass" />
                 <TextBlock FontSize="20" Text="（性別）" Name="txtSex" />
             </StackPanel>
-            <TextBlock Height="30" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Center" Text="経験値 FontSize=18" Name="txtExp" />
-            <TextBlock Height="25" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Center" Text="戦功値 999999" Name="txtMerits" />
+            <TextBlock Height="30" FontSize="19" Foreground="#00FFFF" HorizontalAlignment="Center" Text="経験値 FontSize=19" Name="txtExp" />
+            <TextBlock Height="25" FontSize="19" Foreground="#FFFF00" HorizontalAlignment="Center" Text="戦功値 999999" Name="txtMerits" />
         </StackPanel>
 
-        <StackPanel Canvas.Left="15" Canvas.Top="85">
-            <TextBlock Height="30" FontSize="18" Foreground="#FFC800" Text="身分" Name="txtRank" />
-            <TextBlock Height="25" FontSize="18" Foreground="#FFFF00" Text="信用度・忠誠" Name="txtLoyal" />
+        <StackPanel Canvas.Left="15" Canvas.Top="80">
+            <TextBlock Height="30" FontSize="19" Foreground="#FFC800" Text="身分" Name="txtRank" />
+            <TextBlock Height="25" FontSize="19" Foreground="#FFFF00" Text="信用度・忠誠" Name="txtLoyal" />
         </StackPanel>
-        <StackPanel Canvas.Left="355" Canvas.Top="85" Width="200">
-            <TextBlock Height="30" FontSize="18" Foreground="#FFFF00" HorizontalAlignment="Right" Text="所持金 10485769" Name="txtMoney" />
-            <TextBlock Height="25" FontSize="18" Foreground="#00FFFF" HorizontalAlignment="Right" Text="維持費 999999" Name="txtCost" />
+        <StackPanel Canvas.Left="355" Canvas.Top="80" Width="200">
+            <TextBlock Height="30" FontSize="19" Foreground="#FFFF00" HorizontalAlignment="Right" Text="所持金 10485769" Name="txtMoney" />
+            <TextBlock Height="25" FontSize="19" Foreground="#00FFFF" HorizontalAlignment="Right" Text="維持費 999999" Name="txtCost" />
         </StackPanel>
 
-        <Border Canvas.Left="10" Canvas.Top="150" Height="435" Width="265" BorderBrush="White" BorderThickness="2" />
-        <StackPanel Canvas.Left="15" Canvas.Top="160" Width="85">
+        <Border Canvas.Left="10" Canvas.Top="145" Height="430" Width="265" BorderBrush="White" BorderThickness="2" />
+        <StackPanel Canvas.Left="15" Canvas.Top="150" Width="85">
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="移動型" />
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="HP" />
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="MP" />
@@ -58,7 +58,7 @@
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="召喚" />
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="財政力" />
         </StackPanel>
-        <StackPanel Canvas.Left="100" Canvas.Top="160" Width="162">
+        <StackPanel Canvas.Left="100" Canvas.Top="150" Width="162">
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="FontSize=20" Name="txtMoveType" />
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="9999999/9999999" Name="txtHP" />
             <TextBlock Height="30" FontSize="20" Foreground="White" TextAlignment="Right" Text="99999/99999" Name="txtMP" />
@@ -75,7 +75,7 @@
             <TextBlock Height="30" FontSize="20" Foreground="#FFC800" TextAlignment="Right" Text="9999" Name="txtFinance" />
         </StackPanel>
 
-        <WrapPanel Canvas.Left="285" Canvas.Top="150" Width="272" Orientation="Horizontal" ItemHeight="34" ItemWidth="34" Name="panelSkill">
+        <WrapPanel Canvas.Left="285" Canvas.Top="145" Width="272" Orientation="Horizontal" ItemHeight="34" ItemWidth="34" Name="panelSkill">
             <Button Content="1" FontSize="20" BorderThickness="0"/>
             <Button Content="2" FontSize="20" BorderThickness="0"/>
             <Button Content="3" FontSize="20" BorderThickness="0"/>
@@ -88,13 +88,13 @@
             <Button Content="10" FontSize="20" BorderThickness="0"/>
         </WrapPanel>
 
-        <StackPanel Canvas.Left="285" Canvas.Top="320">
-            <TextBlock Height="20" FontSize="16" Text="耐性は FontSize=16" />
-            <TextBlock Height="20" FontSize="16" Text="なんたらに強い" />
-            <TextBlock Height="20" FontSize="16" Text="かんたらに弱い" />
+        <StackPanel Canvas.Left="285" Canvas.Top="280" Name="panelResist">
+            <TextBlock FontSize="17" Foreground="White" Text="耐性は FontSize=17" />
+            <TextBlock FontSize="17" Foreground="Yellow" Text="即死幻覚麻痺恐慌に強い国" />
+            <TextBlock FontSize="17" Foreground="#40FF40" Text="毒魔吸沈黙混乱に凄く弱い人" />
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="595">
+        <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="585">
             <Button x:Name="btnDismiss" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="解雇"
                     PreviewMouseDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
@@ -130,14 +130,14 @@ namespace WPF_Successor_001_to_Vahren
                 if (bitimg1.PixelWidth > 96)
                 {
                     this.imgFace.Height = bitimg1.PixelHeight;
-                    if (this.imgFace.Height > 200)
+                    if (this.imgFace.Height > 256)
                     {
-                        this.imgFace.Height = 200;
+                        this.imgFace.Height = 256;
                     }
                     this.imgFace.Width = bitimg1.PixelWidth;
-                    if (this.imgFace.Width > 200)
+                    if (this.imgFace.Width > 256)
                     {
-                        this.imgFace.Width = 200;
+                        this.imgFace.Width = 256;
                     }
                 }
                 Canvas.SetLeft(this.imgFace, this.Width - this.imgFace.Width - 10);
@@ -264,6 +264,14 @@ namespace WPF_Successor_001_to_Vahren
                 }
                 this.txtFinance.Text = actual_finance.ToString();
             }
+
+            // スキル
+            this.panelSkill.Children.Clear(); // 最初に全て消去する
+
+            // 耐性
+            this.panelResist.Children.Clear(); // 最初に全て消去する
+
+
         }
 
 


### PR DESCRIPTION
ユニット情報ウインドウの ComboBox の選択肢に色を付けました。
前衛・後衛の頭文字だけの場合よりも識別しやすいです。

領地アイコンにマウスカーソルを乗せると、
領地のヒント情報を左上に表示するようにしました。
部隊数が多いとユニットアイコンが圧縮されます。

勢力選択前に、領地の初期メンバーを配置するようにしました。
これにより、勢力選択時に領地のユニットをヒントで参照できます。