### PR TITLE
領地の説明文を表示する実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -754,14 +754,15 @@ namespace WPF_Successor_001_to_Vahren
             {
                 return;
             }
+
             // マウスを離した時のイベントを追加する
             cast.MouseLeave += ButtonSelectionCity_MouseLeave;
 
             // 同じ勢力の全ての領地を強調する
+            ClassPowerAndCity classPowerAndCity = (ClassPowerAndCity)cast.Tag;
             var gridMapStrategy = (Grid)LogicalTreeHelper.FindLogicalNode(this.canvasMain, StringName.gridMapStrategy);
             if (gridMapStrategy != null)
             {
-                ClassPowerAndCity classPowerAndCity = (ClassPowerAndCity)cast.Tag;
                 if (classPowerAndCity.ClassPower.ListMember.Count > 0)
                 {
                     // プレイヤー勢力なら色を変える
@@ -828,25 +829,19 @@ namespace WPF_Successor_001_to_Vahren
             // 領地のヒントを作成する
             var hintSpot = new UserControl011_SpotHint();
             hintSpot.Name = "HintSpot";
-            hintSpot.Tag = cast.Tag;
-
-            // 左上隅に配置する
-            double offsetLeft = 0, offsetTop = 0;
-            if (this.canvasUI.Margin.Left < 0)
-            {
-                offsetLeft = this.canvasUI.Margin.Left * -1;
-            }
-            if (this.canvasUI.Margin.Top < 0)
-            {
-                offsetTop = this.canvasUI.Margin.Top * -1;
-            }
-            hintSpot.Margin = new Thickness()
-            {
-                Left = offsetLeft,
-                Top = offsetTop
-            };
+            hintSpot.Tag = classPowerAndCity;
             this.canvasUI.Children.Add(hintSpot);
             hintSpot.SetData();
+
+            // 領地の説明文を表示する
+            if (classPowerAndCity.ClassSpot.Text != string.Empty)
+            {
+                var detailSpot = new UserControl025_DetailSpot();
+                detailSpot.Name = "DetailSpot";
+                detailSpot.Tag = classPowerAndCity.ClassSpot;
+                this.canvasUI.Children.Add(detailSpot);
+                detailSpot.SetData();
+            }
         }
         private void ButtonSelectionCity_MouseLeave(object sender, MouseEventArgs e)
         {
@@ -855,10 +850,10 @@ namespace WPF_Successor_001_to_Vahren
             cast.MouseLeave -= ButtonSelectionCity_MouseLeave;
 
             // 勢力領の強調を解除する
+            ClassPowerAndCity classPowerAndCity = (ClassPowerAndCity)cast.Tag;
             var gridMapStrategy = (Grid)LogicalTreeHelper.FindLogicalNode(this.canvasMain, StringName.gridMapStrategy);
             if (gridMapStrategy != null)
             {
-                ClassPowerAndCity classPowerAndCity = (ClassPowerAndCity)cast.Tag;
                 if (classPowerAndCity.ClassPower.ListMember.Count > 0)
                 {
                     for (int i = gridMapStrategy.Children.Count - 1; i >= 0; i += -1) {
@@ -883,6 +878,19 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     this.canvasUI.Children.Remove(itemHint);
                     break;
+                }
+            }
+
+            // 領地の説明文を取り除く
+            if (classPowerAndCity.ClassSpot.Text != string.Empty)
+            {
+                foreach (var itemDetail in this.canvasUI.Children.OfType<UserControl025_DetailSpot>())
+                {
+                    if (itemDetail.Name == "DetailSpot")
+                    {
+                        this.canvasUI.Children.Remove(itemDetail);
+                        break;
+                    }
                 }
             }
         }

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -2304,7 +2304,7 @@ namespace WPF_Successor_001_to_Vahren
                         Left = offsetLeft,
                         Top = this.Margin.Top
                     };
-                    itemWindow.SetData();
+                    itemWindow.DisplayMercenary(mainWindow);
 
                     // 雇用ウインドウをこのウインドウよりも前面に移動させる
                     Canvas.SetZIndex(itemWindow, Canvas.GetZIndex(this) + 1);
@@ -2329,8 +2329,8 @@ namespace WPF_Successor_001_to_Vahren
                     Left = offsetLeft,
                     Top = this.Margin.Top
                 };
-                windowMercenary.SetData();
                 mainWindow.canvasUI.Children.Add(windowMercenary);
+                windowMercenary.SetData();
             }
         }
 

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
@@ -7,7 +7,9 @@
              mc:Ignorable="d" 
              Height="100" Width="400">
     <Canvas IsHitTestVisible="False">
-        <Border Name="borderWindow" Height="100" Width="400" Background="#454545" BorderBrush="Black" BorderThickness="5" Opacity="0.5"/>
+        <Border Background="#454545" BorderBrush="Black" BorderThickness="5" Opacity="0.5"
+                Height="{Binding ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}"
+                Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}" />
 
         <TextBlock Canvas.Left="10" Canvas.Top="10" FontSize="19" Foreground="Aqua" Text="勢力の名前" Name="txtNamePower"/>
         <TextBlock Canvas.Left="10" Canvas.Top="35" FontSize="19" Foreground="White" Text="領地の名前" Name="txtNameSpot"/>

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml.cs
@@ -135,14 +135,29 @@ namespace WPF_Successor_001_to_Vahren
             // ウインドウの大きさを調節する
             if (troop_count > 0)
             {
-                this.borderWindow.Height = 85 + tile_height * troop_count + 10;
+                this.Height = 85 + tile_height * troop_count + 10;
             }
             if (10 + max_width + 10 > 400)
             {
-                this.borderWindow.Width = 10 + max_width + 10;
+                this.Width = 10 + max_width + 10;
             }
 
-        }
+            // 画面の左上隅に配置する
+            double offsetLeft = 0, offsetTop = 0;
+            if (mainWindow.canvasUI.Margin.Left < 0)
+            {
+                offsetLeft = mainWindow.canvasUI.Margin.Left * -1;
+            }
+            if (mainWindow.canvasUI.Margin.Top < 0)
+            {
+                offsetTop = mainWindow.canvasUI.Margin.Top * -1;
+            }
+            this.Margin = new Thickness()
+            {
+                Left = offsetLeft,
+                Top = offsetTop
+            };
 
+        }
     }
 }

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
@@ -10,7 +10,8 @@
             MouseLeftButtonDown="win_MouseLeftButtonDown"
             MouseRightButtonUp="btnClose_Click"
             >
-        <Border Name="borderWindow" Height="515" Width="360" Background="#454545" BorderBrush="Black" BorderThickness="5" />
+        <Border Width="360" Background="#454545" BorderBrush="Black" BorderThickness="5"
+                Height="{Binding ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}" />
 
         <TextBlock Width="310" Canvas.Left="5" Canvas.Top="15" TextAlignment="Center" FontSize="23" Foreground="White" Text="タイトル" Name="txtTitle" />
 
@@ -19,8 +20,7 @@
         <ScrollViewer Name="scrollList" Width="340" Height="448" Canvas.Left="10" Canvas.Top="57" Background="#262626"
                 VerticalScrollBarVisibility="Auto"
                 PreviewMouseLeftButtonDown="Raise_ZOrder"
-                MouseRightButtonUp="Disable_MouseEvent"
-                >
+                MouseRightButtonUp="Disable_MouseEvent" >
             <StackPanel Name="panelList">
 
 <!--

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -197,25 +197,19 @@ namespace WPF_Successor_001_to_Vahren
 */
 
             // スクロール領域の高さとウインドウの高さの差分
-            double diff_height = this.borderWindow.Height - this.scrollList.Height;
+            double diff_height = Canvas.GetTop(this.scrollList) + 10;
             if (item_count < 1)
             {
                 item_count = 1;
             }
+            else if (item_count > 7)
+            {
+                item_count = 7;
+            }
             // リストの項目数が 7個未満なら、ウインドウの高さを低くする
-            if (item_count < 7)
-            {
-                double new_height = (item_height + space_height * 2) * item_count;
-                this.scrollList.Height = new_height;
-                this.borderWindow.Height = new_height + diff_height;
-            }
-            else
-            {
-                // 本来のサイズに戻す
-                this.scrollList.Height = this.Height - diff_height;
-                this.borderWindow.Height = this.Height;
-            }
-
+            double new_height = (item_height + space_height * 2) * item_count;
+            this.scrollList.Height = new_height;
+            this.Height = new_height + diff_height;
         }
 
 

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl025_DetailSpot"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
+             mc:Ignorable="d" 
+             Height="180" Width="530">
+    <Canvas IsHitTestVisible="False">
+        <Border Background="#454545" BorderBrush="Black" BorderThickness="5"
+                Height="{Binding ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}"
+                Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}" />
+
+        <Grid Canvas.Left="465" Canvas.Top="15" Height="50" Width="50">
+            <Image Height="32" Width="32" Name="imgSpot" />
+        </Grid>
+
+        <TextBlock Canvas.Left="15" Canvas.Top="20" FontSize="23" Foreground="White" Name="txtNameSpot" Text="領地の名前"/>
+        <TextBlock Canvas.Left="15" Canvas.Top="65" FontSize="20" Foreground="White" Name="txtDetail" Width="500" TextWrapping="Wrap"
+                Text="spot構造体のtext要素です。自動的に改行されます。手動で改行したい場合は&#10;と入力してください。"/>
+    </Canvas>
+</UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using WPF_Successor_001_to_Vahren._005_Class;
+
+namespace WPF_Successor_001_to_Vahren
+{
+    /// <summary>
+    /// UserControl025_DetailSpot.xaml の相互作用ロジック
+    /// </summary>
+    public partial class UserControl025_DetailSpot : UserControl
+    {
+        public UserControl025_DetailSpot()
+        {
+            InitializeComponent();
+        }
+
+
+        public void SetData()
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            var targetSpot = (ClassSpot)this.Tag;
+            if (targetSpot == null)
+            {
+                return;
+            }
+
+            // 最前面に配置する
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ( (listWindow != null) && (listWindow.Any()) )
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
+            }
+
+            // 領地名
+            this.txtNameSpot.Text = targetSpot.Name;
+
+            // 領地アイコン
+            if (targetSpot.ImagePath != string.Empty)
+            {
+                BitmapImage bitimg1 = new BitmapImage(new Uri(targetSpot.ImagePath));
+                this.imgSpot.Width = bitimg1.PixelWidth;
+                this.imgSpot.Height = bitimg1.PixelHeight;
+                this.imgSpot.Source = bitimg1;
+            }
+
+            // 説明文
+            this.txtDetail.Text = targetSpot.Text;
+
+            // レイアウトが終わるのを待ってから、大きさと位置を調節する
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                // ウインドウの高さを調節する
+                this.Height = Canvas.GetTop(this.txtDetail) + this.txtDetail.ActualHeight + 20;
+
+                // マウスの位置によってウインドウの位置を変える
+                Point pos = Mouse.GetPosition(mainWindow.canvasUI);
+                double offsetLeft = 0, offsetTop = 0;
+                if (mainWindow.canvasUI.Margin.Left < 0)
+                {
+                    offsetLeft = mainWindow.canvasUI.Margin.Left * -1;
+                }
+                if (mainWindow.canvasUI.Margin.Top < 0)
+                {
+                    offsetTop = mainWindow.canvasUI.Margin.Top * -1;
+                }
+                if (pos.X < mainWindow.canvasUI.Width / 2)
+                {
+                    // 画面の右下隅に配置する
+                    this.Margin = new Thickness()
+                    {
+                        Left = mainWindow.canvasUI.Width - offsetLeft - this.Width,
+                        Top = mainWindow.canvasUI.Height - offsetTop - this.Height
+                    };
+                }
+                else
+                {
+                    // 画面の左下隅に配置する
+                    this.Margin = new Thickness()
+                    {
+                        Left = offsetLeft,
+                        Top = mainWindow.canvasUI.Height - offsetTop - this.Height
+                    };
+                }
+
+            }),
+            DispatcherPriority.Loaded);
+
+        }
+    }
+}

--- a/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
+++ b/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
@@ -4,7 +4,7 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>debug battle</ActiveDebugProfile>
+    <ActiveDebugProfile>WPF_Successor_001_to_Vahren</ActiveDebugProfile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="UserControl010_Spot.xaml.cs">
@@ -17,6 +17,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="UserControl020_Mercenary.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="UserControl025_DetailSpot.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="Win010_TestBattle.xaml.cs">
@@ -34,6 +37,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl020_Mercenary.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl025_DetailSpot.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="Win010_TestBattle.xaml">


### PR DESCRIPTION
領地の説明文 spot 構造体の text を表示するようにしました。
領地アイコンをマウスでポイントしたときの位置で、
画面の左下か右下に表示されます。