### PR TITLE
領地ウインドウにスキン適用

### DIFF
--- a/WPF_Successor_001_to_Vahren/CommonWindow.cs
+++ b/WPF_Successor_001_to_Vahren/CommonWindow.cs
@@ -323,8 +323,8 @@ namespace WPF_Successor_001_to_Vahren
 
             Point pt = e.GetPosition(el);
             var thickness = new Thickness();
-            thickness.Left = ri.Margin.Left + (pt.X - cw.ClassGameStatus.StartPoint.X);
-            thickness.Top = ri.Margin.Top + (pt.Y - cw.ClassGameStatus.StartPoint.Y);
+            thickness.Left = Math.Truncate(ri.Margin.Left + (pt.X - cw.ClassGameStatus.StartPoint.X));
+            thickness.Top = Math.Truncate(ri.Margin.Top + (pt.Y - cw.ClassGameStatus.StartPoint.Y));
             ri.Margin = thickness;
         }
         /// <summary>

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -405,7 +405,7 @@ namespace WPF_Successor_001_to_Vahren
                     Point pt = e.GetPosition(el);
 
                     var thickness = new Thickness();
-                    thickness.Left = ri.Margin.Left + (pt.X - this.ClassGameStatus.StartPoint.X);
+                    thickness.Left = Math.Truncate(ri.Margin.Left + (pt.X - this.ClassGameStatus.StartPoint.X));
                     if (thickness.Left > this.CanvasMainWidth / 2)
                     {
                         thickness.Left = this.CanvasMainWidth / 2;
@@ -414,7 +414,7 @@ namespace WPF_Successor_001_to_Vahren
                     {
                         thickness.Left = this.CanvasMainWidth / 2 - ri.Width;
                     }
-                    thickness.Top = ri.Margin.Top + (pt.Y - this.ClassGameStatus.StartPoint.Y);
+                    thickness.Top = Math.Truncate(ri.Margin.Top + (pt.Y - this.ClassGameStatus.StartPoint.Y));
                     if (thickness.Top > this.CanvasMainHeight / 2)
                     {
                         thickness.Top = this.CanvasMainHeight / 2;
@@ -1556,8 +1556,8 @@ namespace WPF_Successor_001_to_Vahren
 
             if (spot_count > 0)
             {
-                target_X /= spot_count;
-                target_Y /= spot_count;
+                target_X = Math.Truncate(target_X / spot_count);
+                target_Y = Math.Truncate(target_Y / spot_count);
 
                 // 目標にする座標をウインドウ中央にする
                 /*
@@ -1585,7 +1585,7 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     Thread.Sleep(5);
 
-                    if (classVec.Hit(new Point(gridMapStrategy.Margin.Left, gridMapStrategy.Margin.Top)))
+                    if (classVec.Hit(new Point(classVec.X, classVec.Y)))
                     {
                         break;
                     }
@@ -1594,11 +1594,13 @@ namespace WPF_Successor_001_to_Vahren
                     {
                         Application.Current.Dispatcher.Invoke((Action)(() =>
                         {
-                            var ge = classVec.Get(new Point(gridMapStrategy.Margin.Left, gridMapStrategy.Margin.Top));
+                            var ge = classVec.Get(new Point(classVec.X, classVec.Y));
+                            classVec.X = ge.X;
+                            classVec.Y = ge.Y;
                             gridMapStrategy.Margin = new Thickness()
                             {
-                                Left = ge.X,
-                                Top = ge.Y
+                                Left = Math.Truncate(ge.X),
+                                Top = Math.Truncate(ge.Y)
                             };
                         }));
                     });
@@ -3509,7 +3511,7 @@ namespace WPF_Successor_001_to_Vahren
             flag_img.Margin = new Thickness
             {
                 Left = flag_img.Width / 2,
-                Top = (gridButton.Height - spot_size) / 2 - flag_img.Height
+                Top = Math.Truncate(gridButton.Height - spot_size) / 2 - flag_img.Height
             };
 
             return flag_img;
@@ -4108,7 +4110,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 Thread.Sleep(5);
 
-                if (classVec.Hit(new Point(gridMapStrategy.Margin.Left, gridMapStrategy.Margin.Top)))
+                if (classVec.Hit(new Point(classVec.X, classVec.Y)))
                 {
                     break;
                 }
@@ -4117,11 +4119,13 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     Application.Current.Dispatcher.Invoke((Action)(() =>
                     {
-                        var ge = classVec.Get(new Point(gridMapStrategy.Margin.Left, gridMapStrategy.Margin.Top));
+                        var ge = classVec.Get(new Point(classVec.X, classVec.Y));
+                        classVec.X = ge.X;
+                        classVec.Y = ge.Y;
                         gridMapStrategy.Margin = new Thickness()
                         {
-                            Left = ge.X,
-                            Top = ge.Y
+                            Left = Math.Truncate(ge.X),
+                            Top = Math.Truncate(ge.Y)
                         };
                     }));
                 });

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
@@ -4,77 +4,100 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
-             mc:Ignorable="d" 
-             Height="680" Width="480">
-    <Canvas
-            MouseLeftButtonDown="win_MouseLeftButtonDown"
-            MouseRightButtonUp="btnClose_Click"
-            >
-        <Border Height="680" Width="480" Background="#454545" BorderBrush="Black" BorderThickness="5" />
+             mc:Ignorable="d" >
+    <Grid MouseLeftButtonDown="win_MouseLeftButtonDown" MouseRightButtonUp="btnClose_Click">
+        <Grid>
+            <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" Opacity="0.9" />
+            <Image Margin="4" Stretch="Fill" Name="imgWindowCenter" Opacity="0.9" />
+        </Grid>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition />
+                <ColumnDefinition Width="16"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="16"/>
+                <RowDefinition />
+                <RowDefinition Height="16"/>
+            </Grid.RowDefinitions>
+            <Image Name="imgWindowLeftTop" />
+            <Rectangle Grid.Column="1" Name="rectWindowTop" />
+            <Image Grid.Column="2" Name="imgWindowRightTop" />
+            <Rectangle Grid.Row="1" Name="rectWindowLeft" />
+            <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight" />
+            <Image Grid.Row="2" Name="imgWindowLeftBottom" />
+            <Rectangle Grid.Row="2" Grid.Column="1" Name="rectWindowBottom" />
+            <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
+        </Grid>
 
-        <Border Height="44" Width="420" BorderBrush="White" BorderThickness="2" Canvas.Left="8" Canvas.Top="8" />
-        <Image Canvas.Left="14" Canvas.Top="14" Height="32" Width="32" Name="imgFlag" />
-        <TextBlock Canvas.Left="55" Canvas.Top="15" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
+        <Canvas Margin="16" Height="670" Width="470">
+            <Border Height="44" Width="425" BorderBrush="White" BorderThickness="2" />
+            <Image Canvas.Left="6" Canvas.Top="6" Height="32" Width="32" Name="imgFlag" />
+            <TextBlock Canvas.Left="45" Canvas.Top="5" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
 
-        <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="435" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
+            <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="435" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
-        <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="60">
-            <Button x:Name="btnSelectAll" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="全部"
-                    PreviewMouseDown="whole_MouseDown"
+            <StackPanel Orientation="Horizontal" Canvas.Left="5" Canvas.Top="55">
+                <Button x:Name="btnSelectAll" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="全部"
+                        PreviewMouseDown="whole_MouseDown"
+                        MouseRightButtonUp="Disable_MouseEvent"
+                        />
+                <Button x:Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="雇用"
+                        Click="btnMercenary_Click"
+                        PreviewMouseDown="Raise_ZOrder"
+                        MouseRightButtonUp="Disable_MouseEvent"
+                        />
+                <Button x:Name="btnPolitics" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="内政"
+                        PreviewMouseDown="Raise_ZOrder"
+                        MouseRightButtonUp="Disable_MouseEvent"
+                        />
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Canvas.Left="10" Canvas.Top="95">
+                <TextBlock FontSize="20" Foreground="Aqua" Text="経済 1000" Name="txtGain" />
+                <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="城壁 150" Name="txtCastle" />
+                <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="戦力 1234567" Name="txtForce" />
+                <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="部隊 16/16" Name="txtTroopCount" />
+            </StackPanel>
+
+            <ScrollViewer Width="460" Height="535" Canvas.Left="5" Canvas.Top="130" Background="#282828"
+                    HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Visible"
+                    PreviewMouseLeftButtonDown="Raise_ZOrder"
                     MouseRightButtonUp="Disable_MouseEvent"
-                    />
-            <Button x:Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="雇用"
-                    Click="btnMercenary_Click"
-                    PreviewMouseDown="Raise_ZOrder"
-                    MouseRightButtonUp="Disable_MouseEvent"
-                    />
-            <Button x:Name="btnPolitics" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Focusable="False" Content="内政"
-                    PreviewMouseDown="Raise_ZOrder"
-                    MouseRightButtonUp="Disable_MouseEvent"
-                    />
-        </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Canvas.Left="15" Canvas.Top="100">
-            <TextBlock FontSize="20" Foreground="Aqua" Text="経済 1000" Name="txtGain" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="城壁 150" Name="txtCastle" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="戦力 1234567" Name="txtForce" />
-            <TextBlock FontSize="20" Margin="15,0,0,0" Foreground="Aqua" Text="部隊 16/16" Name="txtTroopCount" />
-        </StackPanel>
-
-        <ScrollViewer Width="460" Height="535" Canvas.Left="10" Canvas.Top="135" Background="#262626"
-                HorizontalScrollBarVisibility="Auto"
-                VerticalScrollBarVisibility="Visible"
-                PreviewMouseLeftButtonDown="Raise_ZOrder"
-                MouseRightButtonUp="Disable_MouseEvent"
-                >
-            <Canvas Name="canvasSpotUnit" HorizontalAlignment="Left" VerticalAlignment="Top">
+                    >
+                <Canvas Name="canvasSpotUnit" HorizontalAlignment="Left" VerticalAlignment="Top">
 
 <!--
-                <StackPanel Orientation="Horizontal" Height="66">
-                    <StackPanel>
-                        <Button Height="29" Margin="2" FontSize="17" Content="出撃" />
-                        <ComboBox Width="44" Height="29" Margin="2" FontSize="17">
-                            <ComboBoxItem Content="F"/>
-                            <ComboBoxItem Content="M"/>
-                            <ComboBoxItem Content="B"/>
-                        </ComboBox>
+                    <StackPanel Orientation="Horizontal" Height="66">
+                        <StackPanel>
+                            <Button Height="29" Margin="2" FontSize="17" Content="出撃" />
+                            <ComboBox Width="50" Height="29" Margin="2" FontSize="17">
+                                <ComboBoxItem Content="F"/>
+                                <ComboBoxItem Content="M"/>
+                                <ComboBoxItem Content="B"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel>
+                            <Image Height="48" Width="48" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
+                            <TextBlock Height="18" FontSize="16" Foreground="White" TextAlignment="Center" Text="lv199E" />
+                        </StackPanel>
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
+                        <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
                     </StackPanel>
-                    <StackPanel>
-                        <Image Height="48" Width="48" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
-                        <TextBlock Height="18" FontSize="16" Foreground="White" TextAlignment="Center" Text="lv199E" />
-                    </StackPanel>
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                    <Button Width="48" Height="66" Background="Transparent" BorderThickness="0" />
-                </StackPanel>
 -->
 
-            </Canvas>
-        </ScrollViewer>
+                </Canvas>
+            </ScrollViewer>
+        </Canvas>
 
-    </Canvas>
+    </Grid>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -62,6 +62,104 @@ namespace WPF_Successor_001_to_Vahren
 
             // 領地の情報を表示する
             DisplaySpotStatus(mainWindow);
+
+            // ウインドウ枠
+            SetWindowFrame(mainWindow);
+        }
+
+        // ウインドウ枠を作る
+        private void SetWindowFrame(MainWindow mainWindow)
+        {
+            // ウインドウスキンを読み込む
+            List<string> strings = new List<string>();
+            strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+            strings.Add("006_WindowImage");
+            // 自勢力かどうかで枠を変える
+            if (_isControl)
+            {
+                strings.Add("wnd0.png");
+            }
+            else
+            {
+                strings.Add("wnd1.png");
+            }
+            string path = System.IO.Path.Combine(strings.ToArray());
+            if (System.IO.File.Exists(path) == false)
+            {
+                // 画像が存在しない場合は、デザイン時のまま（色や透明度は xaml で指定する）
+                return;
+            }
+            var skin_bitmap = new BitmapImage(new Uri(path));
+            Int32Rect rect;
+            ImageBrush myImageBrush;
+
+            // RPGツクールXP (192x128) と VX (128x128) のスキンに対応する
+            if ((skin_bitmap.PixelHeight != 128) || ((skin_bitmap.PixelWidth != 128) && (skin_bitmap.PixelWidth != 192)))
+            {
+                // その他の画像は、そのまま引き延ばして表示する
+                // ブラシ設定によって、タイルしたり、アスペクト比を保ったりすることも可能
+                myImageBrush = new ImageBrush(skin_bitmap);
+                myImageBrush.Stretch = Stretch.Fill;
+                this.rectWindowPlane.Fill = myImageBrush;
+                return;
+            }
+
+            // 不要な背景を表示しない
+            this.rectShadowRight.Visibility = Visibility.Hidden;
+            this.rectShadowBottom.Visibility = Visibility.Hidden;
+            this.rectWindowPlane.Visibility = Visibility.Hidden;
+
+            // 中央
+            rect = new Int32Rect(0, 0, skin_bitmap.PixelWidth - 64, skin_bitmap.PixelWidth - 64);
+            this.imgWindowCenter.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 左上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 0, 16, 16);
+            this.imgWindowLeftTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 0, 16, 16);
+            this.imgWindowRightTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 左下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 48, 16, 16);
+            this.imgWindowLeftBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 48, 16, 16);
+            this.imgWindowRightBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 0, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowTop.Fill = myImageBrush;
+
+            // 下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 48, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowBottom.Fill = myImageBrush;
+
+            // 左
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowLeft.Fill = myImageBrush;
+
+            // 右
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowRight.Fill = myImageBrush;
         }
 
         // 領地のユニットを変更した際に、ユニット表示だけを更新する
@@ -1663,8 +1761,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 var thickness = new Thickness();
-                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
-                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
+                thickness.Left = Math.Truncate(this.Margin.Left + (pt.X - _startPoint.X));
+                thickness.Top = Math.Truncate(this.Margin.Top + (pt.Y - _startPoint.Y));
                 this.Margin = thickness;
             }
         }
@@ -2294,7 +2392,7 @@ namespace WPF_Successor_001_to_Vahren
             classCityAndUnit.ClassUnit = null;
 
             // 領地ウインドウの右横に雇用ウインドウを表示する
-            double offsetLeft = this.Margin.Left + this.Width;
+            double offsetLeft = this.Margin.Left + this.ActualWidth;
 
             // 既に雇用ウインドウが表示されてる場合は再利用する
             bool isFound = false;

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
@@ -17,10 +17,11 @@
 
         <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="315" Canvas.Top="10" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
-        <ScrollViewer Name="scrollList" Width="340" Height="448" Canvas.Left="10" Canvas.Top="57" Background="#262626"
+        <ScrollViewer Name="scrollList" Width="340" Height="448" Canvas.Left="10" Canvas.Top="57" Background="#282828"
                 VerticalScrollBarVisibility="Auto"
                 PreviewMouseLeftButtonDown="Raise_ZOrder"
-                MouseRightButtonUp="Disable_MouseEvent" >
+                MouseRightButtonUp="Disable_MouseEvent"
+                >
             <StackPanel Name="panelList">
 
 <!--

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -57,11 +57,8 @@ namespace WPF_Successor_001_to_Vahren
             ClassCityAndUnit classCityAndUnit = (ClassCityAndUnit)this.Tag;
             ClassPower targetPower = classCityAndUnit.ClassPowerAndCity.ClassPower;
             ClassSpot targetSpot = classCityAndUnit.ClassPowerAndCity.ClassSpot;
-            if (classCityAndUnit.ClassUnit == null)
-            {
-                throw new Exception();
-            }
-            ClassUnit targetUnit = classCityAndUnit.ClassUnit;
+            // null かどうかで、呼び出し元（ユニットか領地）を識別する
+            ClassUnit? targetUnit = classCityAndUnit.ClassUnit;
 
             // タイトル
             if (targetSpot == null)

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
@@ -5,9 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             d:DesignHeight="200" d:DesignWidth="532"
-             >
-    <Grid  IsHitTestVisible="False">
+             d:DesignHeight="200" d:DesignWidth="542">
+    <Grid IsHitTestVisible="False">
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
@@ -118,7 +118,7 @@ namespace WPF_Successor_001_to_Vahren
             List<string> strings = new List<string>();
             strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
             strings.Add("006_WindowImage");
-            strings.Add("wnd0.png");
+            strings.Add("wnd2.png");
             string path = System.IO.Path.Combine(strings.ToArray());
             if (System.IO.File.Exists(path) == false)
             {
@@ -130,7 +130,7 @@ namespace WPF_Successor_001_to_Vahren
             ImageBrush myImageBrush;
 
             // RPGツクールXP (192x128) と VX (128x128) のスキンに対応する
-            if ((skin_bitmap.PixelHeight != 128) || ((skin_bitmap.PixelWidth == 128) && (skin_bitmap.PixelWidth == 192)))
+            if ((skin_bitmap.PixelHeight != 128) || ((skin_bitmap.PixelWidth != 128) && (skin_bitmap.PixelWidth != 192)))
             {
                 // その他の画像は、そのまま引き延ばして表示する
                 // ブラシ設定によって、タイルしたり、アスペクト比を保ったりすることも可能


### PR DESCRIPTION
画像の座標が整数じゃないと、微妙にずれるようです。
一枚だけ表示する際は気にならないんですが、
複数枚を繋ぎ合わせたり、タイルなどで並べたりすると、
つなぎ目に隙間ができたりして変に見えます。

なので、コントロールの位置は整数で指定した方がいいです。
ドラッグ中もコントロールの位置が整数になるよう、
Margin などの数値の小数点以下を切り捨てました。