### PR TITLE
アニメーションの実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -501,8 +501,15 @@ namespace WPF_Successor_001_to_Vahren
                     // ヘルプを作成する
                     var helpWindow = new UserControl030_Help();
                     helpWindow.Name = "Help_SelectPower";
-                    helpWindow.SetData("旗のある領地を左クリックするとプレイ勢力を選択します。\n右クリックするとシナリオ選択画面に戻ります。");
+                    helpWindow.SetData("旗のある領地を左クリックするとプレイ勢力を選択します。\n領地以外を左ドラッグするとワールドマップを動かせます。\n右クリックするとシナリオ選択画面に戻ります。");
                     this.canvasUI.Children.Add(helpWindow);
+
+                    // 領地のヒントが表示されてる時はヘルプを隠す
+                    var hintSpot = (UserControl011_SpotHint)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "HintSpot");
+                    if (hintSpot != null)
+                    {
+                        helpWindow.Visibility = Visibility.Hidden;
+                    }
                     break;
                 default:
                     break;
@@ -519,13 +526,10 @@ namespace WPF_Successor_001_to_Vahren
                     cast.MouseLeave -= GridMapStrategy_MouseLeave;
 
                     // 表示中のヘルプを取り除く
-                    foreach (var itemHelp in this.canvasUI.Children.OfType<UserControl030_Help>())
+                    var itemHelp = (UserControl030_Help)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "Help_SelectPower");
+                    if (itemHelp != null)
                     {
-                        if (itemHelp.Name == "Help_SelectPower")
-                        {
-                            this.canvasUI.Children.Remove(itemHelp);
-                            break;
-                        }
+                        this.canvasUI.Children.Remove(itemHelp);
                     }
                     break;
                 default:
@@ -771,11 +775,11 @@ namespace WPF_Successor_001_to_Vahren
                     {
                         // 16進数で色を指定する場合はこちら
                         //myBrush = (SolidColorBrush)(new BrushConverter().ConvertFrom("#00FFFF"));
-                        myBrush = Brushes.Cyan;
+                        myBrush = Brushes.Cyan; // #00FFFF
                     }
                     else
                     {
-                        myBrush = Brushes.Lime;
+                        myBrush = Brushes.Lime; // #00FF00
                     }
 
                     // 円の周りをぼかす
@@ -881,13 +885,10 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // 領地のヒントは一個だけなので、見つけたら取り除いて終わる
-            foreach (var itemHint in this.canvasUI.Children.OfType<UserControl011_SpotHint>())
+            var hintSpot = (UserControl011_SpotHint)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "HintSpot");
+            if (hintSpot != null)
             {
-                if (itemHint.Name == "HintSpot")
-                {
-                    this.canvasUI.Children.Remove(itemHint);
-                    break;
-                }
+                this.canvasUI.Children.Remove(hintSpot);
             }
 
             // ヘルプを隠してた場合は、最前面のヘルプだけ表示する
@@ -918,25 +919,13 @@ namespace WPF_Successor_001_to_Vahren
                 }
             }
 
-            foreach (var itemHelp in this.canvasUI.Children.OfType<UserControl030_Help>())
-            {
-                if (itemHelp.Name == "Help_SelectPower")
-                {
-                    itemHelp.Visibility = Visibility.Visible;
-                    break;
-                }
-            }
-
             // 領地の説明文を取り除く
             if (classPowerAndCity.ClassSpot.Text != string.Empty)
             {
-                foreach (var itemDetail in this.canvasUI.Children.OfType<UserControl025_DetailSpot>())
+                var itemDetail = (UserControl025_DetailSpot)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "DetailSpot");
+                if (itemDetail != null)
                 {
-                    if (itemDetail.Name == "DetailSpot")
-                    {
-                        this.canvasUI.Children.Remove(itemDetail);
-                        break;
-                    }
+                    this.canvasUI.Children.Remove(itemDetail);
                 }
             }
         }

--- a/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl011_SpotHint.xaml
@@ -10,7 +10,7 @@
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
-            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" Opacity="0.5" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
         </Grid>
         <Grid>
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
WPFのアニメーション機能を使ったエフェクトの実験です。

勢力選択画面において、
右上の勢力選択メニューの勢力ボタンにマウスカーソルを乗せると、
その勢力の領地をアニメーション付きで強調表示するようにしました。

領地アイコンにマウスカーソルを乗せた際に表示される
領地のヒントの背景を常に不透明にしました。
他のヒントの背景が不透明なので、外観に統一性を持たせました。