### PR TITLE
スキル情報の表示など

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml
@@ -12,8 +12,8 @@
         Closing="MainWindow_Closing"
         Height="1024"
         Width="1600"
-        MinHeight="600"
-        MinWidth="800"
+        MinHeight="720"
+        MinWidth="1024"
         Top="0"
         Left="0"
         >

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -505,10 +505,13 @@ namespace WPF_Successor_001_to_Vahren
                     this.canvasUI.Children.Add(helpWindow);
 
                     // 領地のヒントが表示されてる時はヘルプを隠す
-                    var hintSpot = (UserControl011_SpotHint)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "HintSpot");
-                    if (hintSpot != null)
+                    foreach (var itemWindow in this.canvasUI.Children.OfType<UserControl011_SpotHint>())
                     {
-                        helpWindow.Visibility = Visibility.Hidden;
+                        if (itemWindow.Name == "HintSpot")
+                        {
+                            helpWindow.Visibility = Visibility.Hidden;
+                            break;
+                        }
                     }
                     break;
                 default:
@@ -525,11 +528,14 @@ namespace WPF_Successor_001_to_Vahren
                     var cast = (UIElement)sender;
                     cast.MouseLeave -= GridMapStrategy_MouseLeave;
 
-                    // 表示中のヘルプを取り除く
-                    var itemHelp = (UserControl030_Help)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "Help_SelectPower");
-                    if (itemHelp != null)
+                    // 表示中のヘルプを閉じる
+                    foreach (var itemWindow in this.canvasUI.Children.OfType<UserControl030_Help>())
                     {
-                        this.canvasUI.Children.Remove(itemHelp);
+                        if (itemWindow.Name == "Help_SelectPower")
+                        {
+                            this.canvasUI.Children.Remove(itemWindow);
+                            break;
+                        }
                     }
                     break;
                 default:
@@ -861,11 +867,14 @@ namespace WPF_Successor_001_to_Vahren
                 }
             }
 
-            // 領地のヒントを取り除く
-            var hintSpot = (UserControl011_SpotHint)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "HintSpot");
-            if (hintSpot != null)
+            // 領地のヒントを閉じる
+            foreach (var itemWindow in this.canvasUI.Children.OfType<UserControl011_SpotHint>())
             {
-                this.canvasUI.Children.Remove(hintSpot);
+                if (itemWindow.Name == "HintSpot")
+                {
+                    this.canvasUI.Children.Remove(itemWindow);
+                    break;
+                }
             }
 
             // ヘルプを隠してた場合は、最前面のヘルプだけ表示する
@@ -899,10 +908,13 @@ namespace WPF_Successor_001_to_Vahren
             // 領地の説明文を取り除く
             if (classPowerAndCity.ClassSpot.Text != string.Empty)
             {
-                var itemDetail = (UserControl025_DetailSpot)LogicalTreeHelper.FindLogicalNode(this.canvasUI, "DetailSpot");
-                if (itemDetail != null)
+                foreach (var itemWindow in this.canvasUI.Children.OfType<UserControl025_DetailSpot>())
                 {
-                    this.canvasUI.Children.Remove(itemDetail);
+                    if (itemWindow.Name == "DetailSpot")
+                    {
+                        this.canvasUI.Children.Remove(itemWindow);
+                        break;
+                    }
                 }
             }
         }
@@ -1133,6 +1145,7 @@ namespace WPF_Successor_001_to_Vahren
 
 
             {
+                // 勢力一覧ウィンドウを消す
                 var ri2 = (UserControl040_PowerSelect)LogicalTreeHelper.FindLogicalNode(this.canvasUIRightTop, StringName.windowSelectionPowerMini);
                 if (ri2 != null)
                 {

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
@@ -4,7 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
-             mc:Ignorable="d" >
+             mc:Ignorable="d"
+             MinWidth="502" MinHeight="702">
     <Grid UseLayoutRounding="True"
             MouseLeftButtonDown="win_MouseLeftButtonDown"
             MouseRightButtonUp="btnClose_Click"
@@ -12,7 +13,7 @@
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
-            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" Opacity="0.9" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
         </Grid>
         <Grid>
             <Grid.ColumnDefinitions>

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -1857,21 +1857,27 @@ namespace WPF_Successor_001_to_Vahren
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow != null)
             {
-                // メンバーのヘルプを取り除く
-                var helpMember = (UserControl031_HelpMember)LogicalTreeHelper.FindLogicalNode(mainWindow.canvasUI, "HelpMember");
-                if (helpMember != null)
+                // メンバーのヘルプを閉じる
+                foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl031_HelpMember>())
                 {
-                    mainWindow.canvasUI.Children.Remove(helpMember);
+                    if (itemWindow.Name == "HelpMember")
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                        break;
+                    }
                 }
 
                 // ユニットが人材なら
                 if (((ClassUnit)panelUnit.Tag).Talent == "on")
                 {
-                    // ユニット情報のヒントを取り除く
-                    var hintUnit = (UserControl016_UnitHint)LogicalTreeHelper.FindLogicalNode(mainWindow.canvasUI, "UnitHint");
-                    if (hintUnit != null)
+                    // ユニット情報のヒントを閉じる
+                    foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl016_UnitHint>())
                     {
-                        mainWindow.canvasUI.Children.Remove(hintUnit);
+                        if (itemWindow.Name == "UnitHint")
+                        {
+                            mainWindow.canvasUI.Children.Remove(itemWindow);
+                            break;
+                        }
                     }
                 }
 
@@ -2390,12 +2396,14 @@ namespace WPF_Successor_001_to_Vahren
             bool bCloseHint = false;
             if (((ClassUnit)((StackPanel)sender).Tag).Talent == "on")
             {
-                // ユニット情報のヒントを取り除く
-                var hintUnit = (UserControl016_UnitHint)LogicalTreeHelper.FindLogicalNode(mainWindow.canvasUI, "UnitHint");
-                if (hintUnit != null)
+                foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl016_UnitHint>())
                 {
-                    mainWindow.canvasUI.Children.Remove(hintUnit);
-                    bCloseHint = true;
+                    if (itemWindow.Name == "UnitHint")
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                        bCloseHint = true;
+                        break;
+                    }
                 }
             }
 
@@ -2424,8 +2432,8 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // 既に表示されてるユニット・ウインドウをチェックする
+            const int dY = 60, dX = 40, dX2 = 120, dZ = 8;
             int window_id, max_id = 0;
-            const int dY = 60, dX = 40, dX2 = 120;
             var id_list = new List<int>();
             foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl015_Unit>())
             {
@@ -2445,8 +2453,8 @@ namespace WPF_Successor_001_to_Vahren
                         max_id = -1;
                         itemWindow.Margin = new Thickness()
                         {
-                            Left = mainWindow.canvasUI.Width - offsetLeft - itemWindow.MinWidth - ((window_id - 1) % 10) * dX - ((window_id - 1) / 10) * dX2,
-                            Top = offsetTop + ((window_id - 1) % 10) * dY + dY
+                            Left = mainWindow.canvasUI.Width - offsetLeft - itemWindow.MinWidth - ((window_id - 1) % dZ) * dX - ((window_id - 1) / dZ) * dX2,
+                            Top = offsetTop + ((window_id - 1) % dZ) * dY
                         };
 
                         // ユニット・ウインドウをこのウインドウよりも前面に移動させる
@@ -2455,11 +2463,6 @@ namespace WPF_Successor_001_to_Vahren
                         // ヒントを閉じた場合は右上から移動させる
                         if (bCloseHint)
                         {
-                            var animeOpacity = new DoubleAnimation();
-                            animeOpacity.From = 0.5;
-                            animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
-                            itemWindow.rectWindowPlane.BeginAnimation(Rectangle.OpacityProperty, animeOpacity);
-
                             var animeMargin = new ThicknessAnimation();
                             animeMargin.From = new Thickness()
                             {
@@ -2497,8 +2500,8 @@ namespace WPF_Successor_001_to_Vahren
                 windowUnit.Name = "WindowUnit" + window_id.ToString();
                 windowUnit.Margin = new Thickness()
                 {
-                    Left = mainWindow.canvasUI.Width - offsetLeft - windowUnit.MinWidth - ((window_id - 1) % 10) * dX - ((window_id - 1) / 10) * dX2,
-                    Top = offsetTop + ((window_id - 1) % 10) * dY + dY
+                    Left = mainWindow.canvasUI.Width - offsetLeft - windowUnit.MinWidth - ((window_id - 1) % dZ) * dX - ((window_id - 1) / dZ) * dX2,
+                    Top = offsetTop + ((window_id - 1) % dZ) * dY
                 };
                 windowUnit.SetData();
                 mainWindow.canvasUI.Children.Add(windowUnit);
@@ -2506,11 +2509,6 @@ namespace WPF_Successor_001_to_Vahren
                 // ヒントを閉じた場合は右上から移動させる
                 if (bCloseHint)
                 {
-                    var animeOpacity = new DoubleAnimation();
-                    animeOpacity.From = 0.5;
-                    animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
-                    windowUnit.rectWindowPlane.BeginAnimation(Rectangle.OpacityProperty, animeOpacity);
-
                     var animeMargin = new ThicknessAnimation();
                     animeMargin.From = new Thickness()
                     {
@@ -2525,7 +2523,7 @@ namespace WPF_Successor_001_to_Vahren
                     var animeOpacity = new DoubleAnimation();
                     animeOpacity.From = 0.1;
                     animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
-                    windowUnit.BeginAnimation(Rectangle.OpacityProperty, animeOpacity);
+                    windowUnit.BeginAnimation(Grid.OpacityProperty, animeOpacity);
                 }
             }
             id_list.Clear();
@@ -2598,6 +2596,25 @@ namespace WPF_Successor_001_to_Vahren
                 };
                 windowMercenary.SetData();
                 mainWindow.canvasUI.Children.Add(windowMercenary);
+
+                // 親ウインドウから出てくるように見せる
+                double offsetFrom = this.Margin.Left;
+                if (offsetLeft > offsetFrom)
+                {
+                    offsetFrom = offsetLeft - windowMercenary.MinWidth;
+                }
+                var animeMargin = new ThicknessAnimation();
+                animeMargin.From = new Thickness()
+                {
+                    Left = offsetFrom,
+                    Top = this.Margin.Top
+                };
+                animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.25));
+                windowMercenary.BeginAnimation(Grid.MarginProperty, animeMargin);
+                var animeOpacity = new DoubleAnimation();
+                animeOpacity.From = 0.1;
+                animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
+                windowMercenary.BeginAnimation(Grid.OpacityProperty, animeOpacity);
             }
         }
 
@@ -2642,10 +2659,13 @@ namespace WPF_Successor_001_to_Vahren
             mainWindow.canvasUI.Children.Add(helpWindow);
 
             // メンバーにできるユニットが表示されてる時はヘルプを隠す
-            var helpMember = (UserControl031_HelpMember)LogicalTreeHelper.FindLogicalNode(mainWindow.canvasUI, "HelpMember");
-            if (helpMember != null)
+            foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl031_HelpMember>())
             {
-                helpWindow.Visibility = Visibility.Hidden;
+                if (itemWindow.Name == "HelpMember")
+                {
+                    helpWindow.Visibility = Visibility.Hidden;
+                    break;
+                }
             }
         }
         private void win_MouseLeave(object sender, MouseEventArgs e)

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
@@ -560,6 +560,16 @@ namespace WPF_Successor_001_to_Vahren
             helpWindow.Name = "Help_" + this.Name;
             helpWindow.SetData("ウィンドウ内を右クリックするとウィンドウを閉じます。");
             mainWindow.canvasUI.Children.Add(helpWindow);
+
+            // スキルのヒントが表示されてる時はヘルプを隠す
+            foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl046_SkillHint>())
+            {
+                if (itemWindow.Name == "SkillHint")
+                {
+                    helpWindow.Visibility = Visibility.Hidden;
+                    break;
+                }
+            }
         }
         private void win_MouseLeave(object sender, MouseEventArgs e)
         {

--- a/WPF_Successor_001_to_Vahren/UserControl016_UnitHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl016_UnitHint.xaml
@@ -10,7 +10,7 @@
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
-            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" Opacity="0.5" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
             <Image Margin="0,0,21,21" HorizontalAlignment="Right" VerticalAlignment="Bottom" Height="96" Width="96" Name="imgFace" />
         </Grid>
         <Grid>

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
@@ -14,7 +14,7 @@
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
-            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" Opacity="0.9" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
         </Grid>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -46,8 +46,7 @@
             <Button x:Name="btnClose" HorizontalAlignment="Right" VerticalAlignment="Top" Width="35" Height="35" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
             <ScrollViewer Grid.Row="1" Name="scrollList" Width="340" Height="490" Margin="5" Background="#282828" Focusable="False"
-                    VerticalScrollBarVisibility="Auto" CanContentScroll="True"
-                    MouseRightButtonUp="Disable_MouseEvent" >
+                    VerticalScrollBarVisibility="Auto" CanContentScroll="True" >
                 <StackPanel Name="panelList">
 
 <!--

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -374,39 +374,6 @@ namespace WPF_Successor_001_to_Vahren
         }
         #endregion
 
-        // ボタン等を右クリックした際に、親コントロールが反応しないようにする
-        private void Disable_MouseEvent(object sender, MouseEventArgs e)
-        {
-            var mainWindow = (MainWindow)Application.Current.MainWindow;
-            if (mainWindow != null)
-            {
-                // 最前面に移動させる
-                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
-                if ((listWindow != null) && (listWindow.Any()))
-                {
-                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
-                    Canvas.SetZIndex(this, maxZ + 1);
-                }
-            }
-
-            e.Handled = true;
-        }
-
-        // ボタン等をクリックした際に、UserControlを最前面に移動させる
-        private void Raise_ZOrder(object sender, MouseEventArgs e)
-        {
-            var mainWindow = (MainWindow)Application.Current.MainWindow;
-            if (mainWindow != null)
-            {
-                // 最前面に移動させる
-                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
-                if ((listWindow != null) && (listWindow.Any()))
-                {
-                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
-                    Canvas.SetZIndex(this, maxZ + 1);
-                }
-            }
-        }
 
         // 雇用ウインドウにカーソルを乗せた時
         private void win_MouseEnter(object sender, MouseEventArgs e)
@@ -623,6 +590,9 @@ namespace WPF_Successor_001_to_Vahren
         // ボタンを右クリックすると部隊の空の分まで雇う
         private void btnUnit_MouseRightButtonUp(object sender, MouseEventArgs e)
         {
+            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
+            e.Handled = true;
+
             // 右ボタンを押した時にイベント・ハンドラーが追加されるので、必ず押してるはず
             UIElement el = (UIElement)sender;
             el.ReleaseMouseCapture();

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -171,6 +171,7 @@ namespace WPF_Successor_001_to_Vahren
                 buttonItem.Tag = itemPower;
                 buttonItem.Background = Brushes.Transparent;
                 buttonItem.HorizontalContentAlignment = HorizontalAlignment.Left;
+                buttonItem.Focusable = false;
                 buttonItem.Click += btnPowerSelect_Click;
                 buttonItem.MouseEnter += btnPowerSelect_MouseEnter;
                 this.panelList.Children.Add(buttonItem);

--- a/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml
@@ -1,0 +1,57 @@
+﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl045_Skill"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
+             mc:Ignorable="d" 
+             d:DesignHeight="250" d:DesignWidth="400">
+    <Grid UseLayoutRounding="True"
+            MouseLeftButtonDown="win_MouseLeftButtonDown"
+            MouseRightButtonUp="btnClose_Click">
+        <Grid>
+            <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
+        </Grid>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition />
+                <ColumnDefinition Width="16"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="16"/>
+                <RowDefinition />
+                <RowDefinition Height="16"/>
+            </Grid.RowDefinitions>
+            <Image Name="imgWindowLeftTop" />
+            <Rectangle Grid.Column="1" Name="rectWindowTop" />
+            <Image Grid.Column="2" Name="imgWindowRightTop" />
+            <Rectangle Grid.Row="1" Name="rectWindowLeft" />
+            <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight" />
+            <Image Grid.Row="2" Name="imgWindowLeftBottom" />
+            <Rectangle Grid.Row="2" Grid.Column="1" Name="rectWindowBottom" />
+            <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
+        </Grid>
+
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="25"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <StackPanel Margin="40,0" VerticalAlignment="Bottom" Name="panelTitle">
+                <TextBlock Height="25" FontSize="19" Foreground="#c8ffff" Name="txtNameSkill" Text="スキルの名前"/>
+            </StackPanel>
+            <Grid Name="gridSkillIcon" Width="34" Height="35" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
+            <Button x:Name="btnClose" HorizontalAlignment="Right" VerticalAlignment="Top" Width="35" Height="35" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
+            <TextBlock Grid.Row="1" Margin="5,0" FontSize="19" Foreground="White" Name="txtFunc" Text="（スキルの種類）"/>
+            <TextBlock Grid.Row="2" Margin="5,0" MinHeight="25" FontSize="19" LineHeight="25" Foreground="#ffc800" Name="txtHelp" Text="ヘルプの文章&#xa;シナリオ作者が改行することも可能"/>
+
+            <TextBlock Grid.Row="3" Margin="5,0" FontSize="19" LineHeight="25" Foreground="White" Name="txtDefault" Text="標準でスキル説明文が自動的に生成される。&#xa;改行もコードで書き込む。"/>
+
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using WPF_Successor_001_to_Vahren._005_Class;
+
+namespace WPF_Successor_001_to_Vahren
+{
+    /// <summary>
+    /// UserControl045_Skill.xaml の相互作用ロジック
+    /// </summary>
+    public partial class UserControl045_Skill : UserControl
+    {
+        public UserControl045_Skill()
+        {
+            InitializeComponent();
+        }
+
+        // 最初に呼び出した時
+        public void SetData()
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // 最前面に配置する
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ( (listWindow != null) && (listWindow.Any()) )
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
+            }
+
+            // スキルの情報を表示する
+            DisplaySkillInfo(mainWindow);
+
+            // ウインドウ枠
+            SetWindowFrame(mainWindow);
+        }
+
+        // ウインドウ枠を作る
+        private void SetWindowFrame(MainWindow mainWindow)
+        {
+            // ウインドウスキンを読み込む
+            List<string> strings = new List<string>();
+            strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+            strings.Add("006_WindowImage");
+            strings.Add("wnd1.png");
+            string path = System.IO.Path.Combine(strings.ToArray());
+            if (System.IO.File.Exists(path) == false)
+            {
+                // 画像が存在しない場合は、デザイン時のまま（色や透明度は xaml で指定する）
+                return;
+            }
+            var skin_bitmap = new BitmapImage(new Uri(path));
+            Int32Rect rect;
+            ImageBrush myImageBrush;
+
+            // RPGツクールXP (192x128) と VX (128x128) のスキンに対応する
+            if ((skin_bitmap.PixelHeight != 128) || ((skin_bitmap.PixelWidth != 128) && (skin_bitmap.PixelWidth != 192)))
+            {
+                // その他の画像は、そのまま引き延ばして表示する
+                // ブラシ設定によって、タイルしたり、アスペクト比を保ったりすることも可能
+                myImageBrush = new ImageBrush(skin_bitmap);
+                myImageBrush.Stretch = Stretch.Fill;
+                this.rectWindowPlane.Fill = myImageBrush;
+                return;
+            }
+
+            // 不要な背景を表示しない
+            this.rectShadowRight.Visibility = Visibility.Hidden;
+            this.rectShadowBottom.Visibility = Visibility.Hidden;
+
+            // 中央
+            rect = new Int32Rect(0, 0, skin_bitmap.PixelWidth - 64, skin_bitmap.PixelWidth - 64);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Stretch = Stretch.Fill;
+            this.rectWindowPlane.Margin = new Thickness(4, 4, 4, 4);
+            this.rectWindowPlane.Fill = myImageBrush;
+
+            // 左上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 0, 16, 16);
+            this.imgWindowLeftTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 0, 16, 16);
+            this.imgWindowRightTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 左下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 48, 16, 16);
+            this.imgWindowLeftBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 48, 16, 16);
+            this.imgWindowRightBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 0, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowTop.Fill = myImageBrush;
+
+            // 下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 48, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowBottom.Fill = myImageBrush;
+
+            // 左
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowLeft.Fill = myImageBrush;
+
+            // 右
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowRight.Fill = myImageBrush;
+        }
+
+        // 既に表示されていて、表示を更新する際
+        public void DisplaySkillInfo(MainWindow mainWindow)
+        {
+            var classSkill = (ClassSkill)this.Tag;
+            if (classSkill == null)
+            {
+                return;
+            }
+
+            // スキルセット(Yellow)やリーダースキル(White)・アシストスキルなど
+            // 文字の色が用途によって違う。
+            // まだデータが存在しないのでセットしない。
+
+            // スキルのアイコンを重ねて表示する
+            foreach (var itemIcon in Enumerable.Reverse(classSkill.Icon).ToList())
+            {
+                List<string> strings = new List<string>();
+                strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+                strings.Add("041_ChipImageSkill");
+                strings.Add(itemIcon);
+                string path = System.IO.Path.Combine(strings.ToArray());
+                if (System.IO.File.Exists(path) == false)
+                {
+                    // スキル画像が存在しない場合はスキップする
+                    continue;
+                }
+                var bitmap = new BitmapImage(new Uri(path));
+                Image imageSkill = new Image();
+                imageSkill.Source = bitmap;
+                // 小さな画像はそのままのサイズで表示する
+                if ((bitmap.PixelWidth < 32) && (bitmap.PixelHeight < 32))
+                {
+                    imageSkill.Width = bitmap.PixelWidth;
+                    imageSkill.Height = bitmap.PixelHeight;
+                }
+                else
+                {
+                    imageSkill.Width = 32;
+                    imageSkill.Height = 32;
+                }
+                gridSkillIcon.Children.Add(imageSkill);
+            }
+
+            // スキル名
+            this.txtNameSkill.Text = classSkill.Name;
+
+            // Func種類
+            switch (classSkill.Func)
+            {
+                case _010_Enum.SkillFunc.sword:
+                    if (classSkill.Mp > 0)
+                    {
+                        this.txtFunc.Text = "（接近攻撃）消費MP" + classSkill.Mp.ToString();
+                    }
+                    else
+                    {
+                        this.txtFunc.Text = "（接近攻撃）";
+                    }
+                    break;
+                default: // 設定が無い場合は遠距離攻撃・攻撃魔法にする
+                    if (classSkill.Mp > 0)
+                    {
+                        this.txtFunc.Text = "（攻撃魔法）消費MP" + classSkill.Mp.ToString();
+                    }
+                    else
+                    {
+                        this.txtFunc.Text = "（遠距離攻撃）";
+                    }
+                    break;
+            }
+
+            // ヘルプ
+            this.txtHelp.Text = classSkill.Help;
+
+            // 実験用
+            this.txtDefault.Text = "ウインドウ名 = " + this.Name
+                    + "\nNameTag = " + classSkill.NameTag
+                    + "\nSlowPer = " + classSkill.SlowPer.ToString()
+                    + "\nSlowTime = " + classSkill.SlowTime.ToString()
+                    + "\nAttr = " + classSkill.Attr
+                    + "\nStr.Item1 = " + classSkill.Str.Item1
+                    + "\nStr.Item2 = " + classSkill.Str.Item2.ToString()
+                    + "\nRange = " + classSkill.Range.ToString()
+                    + "\nDamageRangeAdjust = " + classSkill.DamageRangeAdjust.ToString()
+                    + "\nRangeMin = " + classSkill.RangeMin.ToString()
+                    + "\nSpeed = " + classSkill.Speed.ToString()
+                    + "\nGunDelay.Item1 = " + classSkill.GunDelay.Item1
+                    + "\nGunDelay.Item2 = " + classSkill.GunDelay.Item2.ToString();
+
+
+        }
+
+
+        private void btnClose_Click(object sender, RoutedEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // キャンバスから自身を取り除く
+            mainWindow.canvasUI.Children.Remove(this);
+        }
+
+        #region ウインドウ移動
+        private bool _isDrag = false; // 外部に公開する必要なし
+        private Point _startPoint;
+
+        private void win_MouseLeftButtonDown(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                // 最前面に移動させる
+                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+                if ( (listWindow != null) && (listWindow.Any()) )
+                {
+                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                    Canvas.SetZIndex(this, maxZ + 1);
+                }
+            }
+
+            // ドラッグを開始する
+            UIElement el = (UIElement)sender;
+            if (el != null)
+            {
+                _isDrag = true;
+                _startPoint = e.GetPosition(el);
+                el.CaptureMouse();
+                el.MouseLeftButtonUp += win_MouseLeftButtonUp;
+                el.MouseMove += win_MouseMove;
+            }
+        }
+        private void win_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            // ドラック中なら終了する
+            if (_isDrag == true)
+            {
+                UIElement el = (UIElement)sender;
+                el.ReleaseMouseCapture();
+                el.MouseLeftButtonUp -= win_MouseLeftButtonUp;
+                el.MouseMove -= win_MouseMove;
+                _isDrag = false;
+            }
+        }
+        private void win_MouseMove(object sender, MouseEventArgs e)
+        {
+            // ドラック中
+            if (_isDrag == true)
+            {
+                UIElement el = (UIElement)sender;
+                Point pt = e.GetPosition(el);
+
+                var thickness = new Thickness();
+                thickness.Left = Math.Truncate(this.Margin.Left + (pt.X - _startPoint.X));
+                thickness.Top = Math.Truncate(this.Margin.Top + (pt.Y - _startPoint.Y));
+                this.Margin = thickness;
+            }
+        }
+        #endregion
+
+    }
+}

--- a/WPF_Successor_001_to_Vahren/UserControl046_SkillHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl046_SkillHint.xaml
@@ -1,0 +1,54 @@
+﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl046_SkillHint"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
+             mc:Ignorable="d" 
+             d:DesignHeight="250" d:DesignWidth="400">
+    <Grid IsHitTestVisible="False" UseLayoutRounding="True">
+        <Grid>
+            <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
+            <Rectangle Margin="0,0,8,8" Name="rectWindowPlane" Fill="#303030" />
+        </Grid>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="16"/>
+                <ColumnDefinition />
+                <ColumnDefinition Width="16"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="16"/>
+                <RowDefinition />
+                <RowDefinition Height="16"/>
+            </Grid.RowDefinitions>
+            <Image Name="imgWindowLeftTop" />
+            <Rectangle Grid.Column="1" Name="rectWindowTop" />
+            <Image Grid.Column="2" Name="imgWindowRightTop" />
+            <Rectangle Grid.Row="1" Name="rectWindowLeft" />
+            <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight" />
+            <Image Grid.Row="2" Name="imgWindowLeftBottom" />
+            <Rectangle Grid.Row="2" Grid.Column="1" Name="rectWindowBottom" />
+            <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
+        </Grid>
+
+        <Grid Margin="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="25"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <StackPanel Margin="40,0" VerticalAlignment="Bottom" Name="panelTitle">
+                <TextBlock Height="25" FontSize="19" Foreground="#c8ffff" Name="txtNameSkill" Text="スキルの名前"/>
+            </StackPanel>
+            <Grid Name="gridSkillIcon" Width="34" Height="35" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
+            <TextBlock Grid.Row="1" Margin="5,0" FontSize="19" Foreground="White" Name="txtFunc" Text="（スキルの種類）"/>
+            <TextBlock Grid.Row="2" Margin="5,0" MinHeight="25" FontSize="19" LineHeight="25" Foreground="#ffc800" Name="txtHelp" Text="ヘルプの文章&#xa;シナリオ作者が改行することも可能"/>
+
+            <TextBlock Grid.Row="3" Margin="5,0" FontSize="19" LineHeight="25" Foreground="White" Name="txtDefault" Text="標準でスキル説明文が自動的に生成される。&#xa;改行もコードで書き込む。"/>
+
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl046_SkillHint.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl046_SkillHint.xaml.cs
@@ -9,36 +9,27 @@ using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using System.Windows.Threading;
 using WPF_Successor_001_to_Vahren._005_Class;
 
 namespace WPF_Successor_001_to_Vahren
 {
     /// <summary>
-    /// UserControl025_DetailSpot.xaml の相互作用ロジック
+    /// UserControl046_SkillHint.xaml の相互作用ロジック
     /// </summary>
-    public partial class UserControl025_DetailSpot : UserControl
+    public partial class UserControl046_SkillHint : UserControl
     {
-        public UserControl025_DetailSpot()
+        public UserControl046_SkillHint()
         {
             InitializeComponent();
         }
-
 
         public void SetData()
         {
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
-            {
-                return;
-            }
-
-            var targetSpot = (ClassSpot)this.Tag;
-            if (targetSpot == null)
             {
                 return;
             }
@@ -51,84 +42,27 @@ namespace WPF_Successor_001_to_Vahren
                 Canvas.SetZIndex(this, maxZ + 1);
             }
 
-            // 領地名
-            this.txtNameSpot.Text = targetSpot.Name;
-
-            // 領地アイコン
-            if (targetSpot.ImagePath != string.Empty)
-            {
-                BitmapImage bitimg1 = new BitmapImage(new Uri(targetSpot.ImagePath));
-                this.imgSpot.Width = bitimg1.PixelWidth;
-                this.imgSpot.Height = bitimg1.PixelHeight;
-                this.imgSpot.Source = bitimg1;
-            }
-
-            // 説明文
-            this.txtDetail.Text = targetSpot.Text;
+            // スキルの情報を表示する
+            DisplaySkillInfo(mainWindow);
 
             // ウインドウ枠
             SetWindowFrame(mainWindow);
 
-            // 位置を変更する前の状態が見えないようにする
-            this.Visibility = Visibility.Hidden;
-
-            // レイアウトが終わるのを待ってから位置を調節する
-            Dispatcher.BeginInvoke(new Action(() =>
+            // 画面の左上隅に配置する
+            double offsetLeft = 0, offsetTop = 0;
+            if (mainWindow.canvasUI.Margin.Left < 0)
             {
-                // ウインドウの大きさを取得する
-                // 自動サイズを整数にするため、UseLayoutRounding="true" にすること！
-                // （整数にするのが無理な場合は、ここで小数点以下を切り上げればいい）
-                double actual_height = this.ActualHeight;
-
-                // マウスの位置によってウインドウの位置を変える
-                Point pos = Mouse.GetPosition(mainWindow.canvasUI);
-                double offsetLeft = 0, offsetTop = 0;
-                if (mainWindow.canvasUI.Margin.Left < 0)
-                {
-                    offsetLeft = mainWindow.canvasUI.Margin.Left * -1;
-                }
-                if (mainWindow.canvasUI.Margin.Top < 0)
-                {
-                    offsetTop = mainWindow.canvasUI.Margin.Top * -1;
-                }
-                if (pos.X < mainWindow.canvasUI.Width / 2)
-                {
-                    // 画面の右下隅に配置する
-                    this.Margin = new Thickness()
-                    {
-                        Left = mainWindow.canvasUI.Width - offsetLeft - this.MinWidth,
-                        Top = mainWindow.canvasUI.Height - offsetTop - actual_height
-                    };
-                }
-                else
-                {
-                    // 画面の左下隅に配置する
-                    this.Margin = new Thickness()
-                    {
-                        Left = offsetLeft,
-                        Top = mainWindow.canvasUI.Height - offsetTop - actual_height
-                    };
-                }
-                // 位置が決まったら、見えるようにする
-                this.Visibility = Visibility.Visible;
-
-                // 配置が終わったら、しゅっと表示されるようにする（少し上から落ちる）
-                var animeOpacity = new DoubleAnimation();
-                animeOpacity.From = 0.1;
-                animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
-                this.BeginAnimation(Grid.OpacityProperty, animeOpacity);
-                var animeMargin = new ThicknessAnimation();
-                animeMargin.From = new Thickness()
-                {
-                    Left = this.Margin.Left,
-                    Top = this.Margin.Top - 100
-                };
-                animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.25));
-                this.BeginAnimation(Grid.MarginProperty, animeMargin);
-
-            }),
-            DispatcherPriority.Loaded);
-
+                offsetLeft = mainWindow.canvasUI.Margin.Left * -1;
+            }
+            if (mainWindow.canvasUI.Margin.Top < 0)
+            {
+                offsetTop = mainWindow.canvasUI.Margin.Top * -1;
+            }
+            this.Margin = new Thickness()
+            {
+                Left = offsetLeft,
+                Top = offsetTop
+            };
         }
 
         // ウインドウ枠を作る
@@ -138,7 +72,7 @@ namespace WPF_Successor_001_to_Vahren
             List<string> strings = new List<string>();
             strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
             strings.Add("006_WindowImage");
-            strings.Add("wnd2.png");
+            strings.Add("wnd1.png");
             string path = System.IO.Path.Combine(strings.ToArray());
             if (System.IO.File.Exists(path) == false)
             {
@@ -219,6 +153,98 @@ namespace WPF_Successor_001_to_Vahren
             myImageBrush.TileMode = TileMode.Tile;
             this.rectWindowRight.Fill = myImageBrush;
         }
+
+        public void DisplaySkillInfo(MainWindow mainWindow)
+        {
+            var classSkill = (ClassSkill)this.Tag;
+            if (classSkill == null)
+            {
+                return;
+            }
+
+            // スキルセット(Yellow)やリーダースキル(White)・アシストスキルなど
+            // 文字の色が用途によって違う。
+            // まだデータが存在しないのでセットしない。
+
+            // スキルのアイコンを重ねて表示する
+            foreach (var itemIcon in Enumerable.Reverse(classSkill.Icon).ToList())
+            {
+                List<string> strings = new List<string>();
+                strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+                strings.Add("041_ChipImageSkill");
+                strings.Add(itemIcon);
+                string path = System.IO.Path.Combine(strings.ToArray());
+                if (System.IO.File.Exists(path) == false)
+                {
+                    // スキル画像が存在しない場合はスキップする
+                    continue;
+                }
+                var bitmap = new BitmapImage(new Uri(path));
+                Image imageSkill = new Image();
+                imageSkill.Source = bitmap;
+                // 小さな画像はそのままのサイズで表示する
+                if ((bitmap.PixelWidth < 32) && (bitmap.PixelHeight < 32))
+                {
+                    imageSkill.Width = bitmap.PixelWidth;
+                    imageSkill.Height = bitmap.PixelHeight;
+                }
+                else
+                {
+                    imageSkill.Width = 32;
+                    imageSkill.Height = 32;
+                }
+                gridSkillIcon.Children.Add(imageSkill);
+            }
+
+            // スキル名
+            this.txtNameSkill.Text = classSkill.Name;
+
+            // Func種類
+            switch (classSkill.Func)
+            {
+                case _010_Enum.SkillFunc.sword:
+                    if (classSkill.Mp > 0)
+                    {
+                        this.txtFunc.Text = "（接近攻撃）消費MP" + classSkill.Mp.ToString();
+                    }
+                    else
+                    {
+                        this.txtFunc.Text = "（接近攻撃）";
+                    }
+                    break;
+                default: // 設定が無い場合は遠距離攻撃・攻撃魔法にする
+                    if (classSkill.Mp > 0)
+                    {
+                        this.txtFunc.Text = "（攻撃魔法）消費MP" + classSkill.Mp.ToString();
+                    }
+                    else
+                    {
+                        this.txtFunc.Text = "（遠距離攻撃）";
+                    }
+                    break;
+            }
+
+            // ヘルプ
+            this.txtHelp.Text = classSkill.Help;
+
+            // 実験用
+            this.txtDefault.Text = "ウインドウ名 = " + this.Name
+                    + "\nNameTag = " + classSkill.NameTag
+                    + "\nSlowPer = " + classSkill.SlowPer.ToString()
+                    + "\nSlowTime = " + classSkill.SlowTime.ToString()
+                    + "\nAttr = " + classSkill.Attr
+                    + "\nStr.Item1 = " + classSkill.Str.Item1
+                    + "\nStr.Item2 = " + classSkill.Str.Item2.ToString()
+                    + "\nRange = " + classSkill.Range.ToString()
+                    + "\nDamageRangeAdjust = " + classSkill.DamageRangeAdjust.ToString()
+                    + "\nRangeMin = " + classSkill.RangeMin.ToString()
+                    + "\nSpeed = " + classSkill.Speed.ToString()
+                    + "\nGunDelay.Item1 = " + classSkill.GunDelay.Item1
+                    + "\nGunDelay.Item2 = " + classSkill.GunDelay.Item2.ToString();
+
+
+        }
+
 
     }
 }

--- a/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
+++ b/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
@@ -4,7 +4,7 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>debug battle</ActiveDebugProfile>
+    <ActiveDebugProfile>WPF_Successor_001_to_Vahren</ActiveDebugProfile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="UserControl010_Spot.xaml.cs">
@@ -32,6 +32,12 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="UserControl040_PowerSelect.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="UserControl045_Skill.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="UserControl046_SkillHint.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="Win010_TestBattle.xaml.cs">
@@ -64,6 +70,12 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl040_PowerSelect.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl045_Skill.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl046_SkillHint.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="Win010_TestBattle.xaml">


### PR DESCRIPTION
メインウインドウの最小サイズを 1024x720 にしました。

雇用ウインドウを初めて表示する時、しゅっと出現するようにしました。

領地の説明文を表示する時、すとっと出現するようにしました。

ユニット情報ウインドウでスキルのボタンをクリックすると
スキル情報ウインドウを表示するようにしました。
表示内容はまだ未完成です。

ファイルからClassSkillにデータを入れる際に
HelpのテキストをNameに代入していたミスを修正しました。

ユニット情報ウインドウ上のスキルのボタンにカーソルを乗せた際に
スキルのヒントを表示するようにしました。
スキル情報とヒントの内容は同じです。（違う所は閉じるボタンの有無）
スキルのヒントはカーソルを動かすと消えますが、
スキル情報ウインドウはプレイヤーが閉じるまで残ります。