### PR TITLE
テキストウィンドウが下から出てくる

### DIFF
--- a/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Spot/登場領地.txt
+++ b/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Spot/登場領地.txt
@@ -50,7 +50,7 @@ NewFormatSpot spot0009
 	map = "wefwefwefwefw";
 
 	capacity = "6";
-	member = "LineInfantryM14*6,DragoonFrancesca*8,HowitzerC11*7";
+	member = "LineInfantryM14*2,DragoonFrancesca,HowitzerC11";
 	text = "短い文章です。";
 }
 NewFormatSpot spot0010

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -4393,6 +4393,7 @@ namespace WPF_Successor_001_to_Vahren
                 }
                 var textWindow = (UserControl050_Msg)(this.ClassGameStatus.TextWindow);
                 textWindow.SetText(MoldingText(systemFunctionLiteral.Parameters[0].Value, "$"));
+                textWindow.PositionBottom();
                 textWindow.RemoveName();
                 textWindow.RemoveHelp();
                 textWindow.RemoveFace();
@@ -4406,6 +4407,7 @@ namespace WPF_Successor_001_to_Vahren
                 }
                 var textWindow = (UserControl050_Msg)(this.ClassGameStatus.TextWindow);
                 textWindow.SetText(MoldingText(systemFunctionLiteral.Parameters[1].Value, "$"));
+                textWindow.PositionBottom();
 
                 // ユニットの識別名から肩書と名前を取得する
                 string unitNameTag = systemFunctionLiteral.Parameters[0].Value;

--- a/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
@@ -81,6 +81,7 @@ namespace WPF_Successor_001_to_Vahren
             this.Width = mainWindow.canvasTop.ActualWidth;
             this.Height = mainWindow.canvasTop.ActualHeight;
 
+            /*
             // テキストウィンドウを画面の下中央に配置する
             double offsetTop = mainWindow.canvasUI.Margin.Top;
             if (offsetTop < 0)
@@ -92,6 +93,7 @@ namespace WPF_Successor_001_to_Vahren
                 Left = Math.Truncate(this.Width / 2 - this.gridMain.Width / 2),
                 Top = this.Height - this.gridMain.Height - offsetTop
             };
+            */
         }
 
         // ウインドウ枠を作る
@@ -217,7 +219,6 @@ namespace WPF_Successor_001_to_Vahren
             }
         }
 
-/*
         // ウィンドウ位置を変更できるようにする？
         // ヴァーレンの msg2 / talk2 / chat2 は上端に表示される
         public void PositionBottom()
@@ -236,6 +237,7 @@ namespace WPF_Successor_001_to_Vahren
             }
             double newLeft = Math.Truncate(this.Width / 2 - this.gridMain.Width / 2);
             double newTop = this.Height - this.gridMain.Height - offsetTop;
+            // 違う場所にあった場合だけ、アニメーションしながら出現させる
             if ((this.gridMain.Margin.Left != newLeft) || (this.gridMain.Margin.Top != newTop))
             {
                 this.gridMain.Margin = new Thickness()
@@ -245,31 +247,34 @@ namespace WPF_Successor_001_to_Vahren
                 };
 
                 // 画面下から出てくるアニメーションを付ける
-                // 最初から文章が表示されたまま動くと変に見える・・・
-                {
-                    var animeOpacity = new DoubleAnimation();
-                    animeOpacity.From = 0.1;
-                    animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
-                    this.gridMain.BeginAnimation(Grid.OpacityProperty, animeOpacity);
+                // 文章が表示されたまま動くと変なので、アニメーションが終わってから表示する
+                this.txtMain.Visibility = Visibility.Hidden;
 
-                    var animeMargin = new ThicknessAnimation();
-                    animeMargin.From = new Thickness()
-                    {
-                        Left = this.gridMain.Margin.Left,
-                        Top = Math.Truncate(this.gridMain.Margin.Top + this.gridMain.Height / 2)
-                    };
-                    animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.25));
-                    this.gridMain.BeginAnimation(Grid.MarginProperty, animeMargin);
-                }
-            }
-            else
-            {
-                // アニメーションを消す
-                this.gridMain.BeginAnimation(Grid.OpacityProperty, null);
-                this.gridMain.BeginAnimation(Grid.MarginProperty, null);
+                // かなり速く動く（1/8秒で終わる）
+                var animeOpacity = new DoubleAnimation();
+                animeOpacity.From = 0.1;
+                animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.11));
+                this.gridMain.BeginAnimation(Grid.OpacityProperty, animeOpacity);
+
+                var animeMargin = new ThicknessAnimation();
+                animeMargin.From = new Thickness()
+                {
+                    Left = this.gridMain.Margin.Left,
+                    Top = this.gridMain.Margin.Top + Math.Truncate(this.gridMain.Height / 2)
+                };
+                animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.125));
+                animeMargin.Completed += anime_PositionBottom_Completed;
+                this.gridMain.BeginAnimation(Grid.MarginProperty, animeMargin);
             }
         }
-*/
+
+        private void anime_PositionBottom_Completed(object? sender, EventArgs e)
+        {
+            // ウィンドウを動かすアニメーションを消して、文章を表示する
+            this.gridMain.BeginAnimation(Grid.OpacityProperty, null);
+            this.gridMain.BeginAnimation(Grid.MarginProperty, null);
+            this.txtMain.Visibility = Visibility.Visible;
+        }
 
         // 文章の表示を待ってる位置 (マイナスなら待ってない)
         private int _indexWait = -1;


### PR DESCRIPTION
テキストウィンドウの文章をじわじわ表示するのは難しいので諦めました。
とりあえず、ウィンドウが出現する時のアニメーションだけ付けました。
画面下からするっと出てきます。

将来的には、ヴァーレンの msg2 / talk2 のように上端にもウィンドウを出せます。

初期部隊の指定方法が修正されたので、領地に初期配置する数を減らしました。