### PR TITLE
領地ウィンドウを開いてる間の強調

### DIFF
--- a/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticBattle.cs
+++ b/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticBattle.cs
@@ -1188,21 +1188,35 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                         }
 
                         //出撃先領地情報
-                        var aa = classGameStatus.AllListSpot
+                        var targetSpot = classGameStatus.AllListSpot
                                 .Where(x => x.NameTag == convSpots.ClassSpot.NameTag)
                                 .First();
 
+                        // 他の勢力に所属してた場合は、取り除く
+                        if (convSpots.ClassSpot.PowerNameTag != string.Empty)
+                        {
+                            convSpots.ClassPower.ListMember.Remove(convSpots.ClassSpot.NameTag);
+                        }
+
                         //spotの所属情報を書き換え
                         convSpots.ClassSpot.PowerNameTag = selectedItemClassSpot.PowerNameTag;
-                        aa.PowerNameTag = convSpots.ClassSpot.PowerNameTag;
-                        var po = classGameStatus.ListPower
+                        targetSpot.PowerNameTag = convSpots.ClassSpot.PowerNameTag;
+                        var newPower = classGameStatus.ListPower
                                 .Where(x => x.NameTag == convSpots.ClassSpot.PowerNameTag)
                                 .First();
-                        po.ListMember.Add(convSpots.ClassSpot.NameTag);
+                        newPower.ListMember.Add(convSpots.ClassSpot.NameTag);
+                        convSpots.ClassPower = newPower;
+
+                        // 領地に古い旗アイコンがあれば消して、新しい旗アイコンを置く
+                        var worldMap = classGameStatus.WorldMap;
+                        if (worldMap != null)
+                        {
+                            worldMap.ChangeFlag(newPower.FlagPath, convSpots.ClassSpot.NameTag);
+                        }
 
                         ////unitの所属情報を書き換え
                         //防衛部隊を削除、又は他都市へ移動。隣接都市が無ければ放浪する
-                        aa.UnitGroup.Clear();
+                        targetSpot.UnitGroup.Clear();
                         foreach (var item in classGameStatus.AllListSpot.Where(x => x.NameTag == selectedItemClassSpot.NameTag))
                         {
                             foreach (var itemUnitGroup in item.UnitGroup)
@@ -1210,7 +1224,7 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                                 itemUnitGroup.Spot = convSpots.ClassSpot;
                                 itemUnitGroup.FlagDisplay = true;
                                 //unit移動
-                                aa.UnitGroup.Add(itemUnitGroup);
+                                targetSpot.UnitGroup.Add(itemUnitGroup);
                             }
                             //これでは出撃してないユニットも全部消えてしまうので、後で対応、対応したらこのコメント消す
                             item.UnitGroup.Clear();

--- a/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
@@ -372,7 +372,7 @@ namespace WPF_Successor_001_to_Vahren
             if (convSpots.ClassSpot.ListMember.Count == 0 && convSpots.ClassSpot.ListMonster.Count == 0)
             {
                 // 他の勢力に所属してた場合は、取り除く
-                if (convSpots.ClassSpot.PowerNameTag != String.Empty)
+                if (convSpots.ClassSpot.PowerNameTag != string.Empty)
                 {
                     convSpots.ClassPower.ListMember.Remove(convSpots.ClassSpot.NameTag);
                 }

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -61,6 +61,28 @@ namespace WPF_Successor_001_to_Vahren
                 _isControl = false;
             }
 
+            // 領地ウィンドウを開いてる間、ワールドマップ上で強調する
+            var worldMap = mainWindow.ClassGameStatus.WorldMap;
+            if (worldMap != null)
+            {
+                string strFilename;
+                // プレイヤー勢力なら色を変える
+                if (_isControl)
+                {
+                    strFilename = "circle_cyan4.png";
+                }
+                // 中立領地
+                else if (((ClassPowerAndCity)this.Tag).ClassPower.NameTag == string.Empty)
+                {
+                    strFilename = "circle_yellow4.png";
+                }
+                else
+                {
+                    strFilename =  "circle_lime4.png";
+                }
+                worldMap.SpotMarkAnime(strFilename, ((ClassPowerAndCity)this.Tag).ClassSpot.NameTag);
+            }
+
             // 領地の情報を表示する
             DisplaySpotStatus(mainWindow);
 
@@ -1725,6 +1747,13 @@ namespace WPF_Successor_001_to_Vahren
                     mainWindow.canvasUI.Children.Remove(itemWindow);
                     break;
                 }
+            }
+
+            // ワールドマップ上での強調を解除する
+            var worldMap = mainWindow.ClassGameStatus.WorldMap;
+            if (worldMap != null)
+            {
+                worldMap.RemoveSpotMark(((ClassPowerAndCity)this.Tag).ClassSpot.NameTag);
             }
 
             // キャンバスから自身を取り除く

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -365,7 +365,7 @@ namespace WPF_Successor_001_to_Vahren
                 var worldMap = mainWindow.ClassGameStatus.WorldMap;
                 if (worldMap != null)
                 {
-                    worldMap.RemoveMark();
+                    worldMap.RemovePowerMark(classPower.NameTag);
                 }
             }
         }

--- a/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
@@ -177,7 +177,7 @@ namespace WPF_Successor_001_to_Vahren
                                 gridButton.Tag = classPowerAndCity;
                                 //ついでに、スポットの属する勢力名を設定
                                 item.value.PowerNameTag = mainWindow.ClassGameStatus.ListPower[i].NameTag;
-                                 // 旗画像のパスを取得する
+                                // 旗画像のパスを取得する
                                 flag_path = mainWindow.ClassGameStatus.ListPower[i].FlagPath;
                                 ch = true;
                                 break;


### PR DESCRIPTION
戦闘終了後に領地の所属が変化してないのを修正しました。

領地ウィンドウを開いてる間、ワールドマップ上でその領地を強調するようにしました。
ヴァーレンは常に黄色のマークが付いてるけど、自勢力/他勢力/中立で色を変えてみました。