### PR TITLE
アニメーション終了処理の実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -2498,6 +2498,25 @@ namespace WPF_Successor_001_to_Vahren
             return imgFlag;
         }
 
+        // 以下の記事のコードをそのまま使ってます。
+        // 「WPF/C# コントロールの要素をキャプチャする」
+        // https://qiita.com/Sakurai-Shinya/items/81a9c413c3265f0e8587
+        // キャプチャしたい要素（一番親の要素）を引数に渡すとBitmapSourceで返すメソッド
+        public BitmapSource FrameworkElementToBitmapSource(FrameworkElement element)
+        {
+            element.UpdateLayout();
+            var width = element.ActualWidth;
+            var height = element.ActualHeight;
+            var dv = new DrawingVisual();
+            using (var dc = dv.RenderOpen())
+            {
+                dc.DrawRectangle(new BitmapCacheBrush(element), null, new Rect(0, 0, width, height));
+            }
+            var rtb = new RenderTargetBitmap((int)width, (int)height, 96d, 96d, PixelFormats.Pbgra32);
+            rtb.Render(dv);
+            return rtb;
+        }
+
         #region 各種構造体データ読み込みに必要なメソッド群
         /// <summary>
         /// 各種構造体データ読み込み

--- a/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
@@ -268,12 +268,11 @@ namespace WPF_Successor_001_to_Vahren
                     Top = this.gridMain.Margin.Top + Math.Truncate(this.gridMain.Height / 2)
                 };
                 animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.125));
-                animeMargin.Completed += anime_PositionBottom_Completed;
+                animeMargin.Completed += animePositionBottom_Completed;
                 this.gridMain.BeginAnimation(Grid.MarginProperty, animeMargin);
             }
         }
-
-        private void anime_PositionBottom_Completed(object? sender, EventArgs e)
+        private void animePositionBottom_Completed(object? sender, EventArgs e)
         {
             // ウィンドウを動かすアニメーションを消して、文章を表示する
             this.gridMain.BeginAnimation(Grid.OpacityProperty, null);


### PR DESCRIPTION
ワールドマップで領地をポイントした際に、
領地の詳細が存在すると下隅に詳細ウィンドウが表示されます。
そのウィンドウが開く時は「少し上から降りてくる」ように見えて、
閉じる時は「少し上に上がりながら消える」ようにしました。

ウィンドウ自体はすぐに消してるんですが、
ダミー画像を表示してアニメーションさせてます。

領地アイコンをポイントした際に、
ピョコンと上に少し動くエフェクトが表示されます。
これもダミー画像を動かしてるんですが、動いてる間は消えず、
動き終わったら自動的に消えるようにしました。
カーソルをすぐに離したり連続的に動かした時でも、
アニメーションが途切れたり、いきなり元の場所に戻ったりしません。

ただ、問題もあって、ダミー画像のアニメーションには
元になった本来のコントロールのデータを紐づけできないみたい。
（TagやNameは駄目でした。方法があるのかもしれないけど、私には分からず。）
なので、複数のダミー画像があると、アニメーションの終了イベントを
判別できない可能性があります。
カーソルを高速で動かした時に、表示が変になるかもしれません。
不自然さが顕著ならば、また他の方法を試します。