### PR TITLE
出撃ウィンドウを変更する前の準備

### DIFF
--- a/WPF_Successor_001_to_Vahren/005_Class/StringName.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/StringName.cs
@@ -29,6 +29,14 @@ namespace WPF_Successor_001_to_Vahren._005_Class
         public static readonly string buttonClassPowerAndCity = "buttonClassPowerAndCity";
         public static readonly string windowGameResult = "windowGameResult";
 
+        // 出撃選択用領地ウィンドウ（UserControl012_SpotSortie）の Name の接頭語
+        public static readonly string windowSpotSortie = "WindowSpotSortie";
+
+        // メンバーにできるユニットのヘルプ（UserControl031_HelpMember）の Name
+        public static readonly string windowMember = "HelpMember";
+
+        // 出撃ウィンドウ（UserControl065_Sortie）の Name の接頭語
+        public static readonly string windowSortie = "WindowSortie";
 
         //縦
         public static readonly string stackPanelResidentVertical = "stackPanelResidentVertical";

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml
@@ -17,7 +17,7 @@
         Top="0"
         Left="0"
         >
-    <Canvas x:Name="canvasTop" Opacity="1" SizeChanged="canvasTop_SizeChanged">
+    <Canvas x:Name="canvasTop" UseLayoutRounding="True" SizeChanged="canvasTop_SizeChanged">
         <Canvas x:Name="canvasUIRightBottom"
                 Panel.ZIndex="97"
                 Width="{Binding canvasMainWidth}"

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -3018,8 +3018,8 @@ namespace WPF_Successor_001_to_Vahren
                         classVec.Y = ge.Y;
                         worldMap.Margin = new Thickness()
                         {
-                            Left = Math.Truncate(ge.X),
-                            Top = Math.Truncate(ge.Y)
+                            Left = ge.X,
+                            Top = ge.Y
                         };
                     }));
                 });

--- a/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
@@ -369,27 +369,13 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             //兵が存在する都市かチェック
-            if (convSpots.ClassSpot.ListMember.Count == 0 && convSpots.ClassSpot.ListMonster.Count == 0)
+            if (convSpots.ClassSpot.UnitGroup.Count == 0)
             {
-                // 他の勢力に所属してた場合は、取り除く
-                if (convSpots.ClassSpot.PowerNameTag != string.Empty)
-                {
-                    convSpots.ClassPower.ListMember.Remove(convSpots.ClassSpot.NameTag);
-                }
-
-                //spotの所属情報を書き換え
-                convSpots.ClassSpot.PowerNameTag = selectedItem.PowerNameTag;
-                var newPower = mainWindow.ClassGameStatus.ListPower
-                            .Where(x => x.NameTag == selectedItem.PowerNameTag)
-                            .First();
-                newPower.ListMember.Add(convSpots.ClassSpot.NameTag);
-                convSpots.ClassPower = newPower;
-
-                // 領地に古い旗アイコンがあれば消して、新しい旗アイコンを置く
+                // ワールドマップ領地の所属勢力を変更する
                 var worldMap = mainWindow.ClassGameStatus.WorldMap;
                 if (worldMap != null)
                 {
-                    worldMap.ChangeFlag(newPower.FlagPath, convSpots.ClassSpot.NameTag);
+                    worldMap.ChangeSpotPower(convSpots.ClassSpot.NameTag, selectedItem.PowerNameTag);
                 }
 
                 //unitの所属情報を書き換え

--- a/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
@@ -338,7 +338,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_btnTurnEnd";
-            helpWindow.SetData("ターンを終了します。");
+            helpWindow.SetText("ターンを終了します。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void btnTurnEnd_MouseLeave(object sender, MouseEventArgs e)
@@ -418,7 +418,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu";
-            helpWindow.SetData("※敵領地を右クリックすると出撃ウィンドウが出ます。\n（戦争する時は敵領地を右クリックしてください）");
+            helpWindow.SetText("※敵領地を右クリックすると出撃ウィンドウが出ます。\n（戦争する時は敵領地を右クリックしてください）");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void win_MouseLeave(object sender, MouseEventArgs e)
@@ -497,7 +497,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_TotalCost";
-            helpWindow.SetData("全ユニットの維持費の合計値です。");
+            helpWindow.SetText("全ユニットの維持費の合計値です。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void TotalCost_MouseLeave(object sender, MouseEventArgs e)
@@ -576,7 +576,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_TotalFinance";
-            helpWindow.SetData("全ユニットの財政力の合計値です。");
+            helpWindow.SetText("全ユニットの財政力の合計値です。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void TotalFinance_MouseLeave(object sender, MouseEventArgs e)
@@ -655,7 +655,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_TrainingAverage";
-            helpWindow.SetData("訓練限界値は勢力の全人材ユニットの平均レベルです。\nこれより低い一般兵のレベルが訓練で上昇します。");
+            helpWindow.SetText("訓練限界値は勢力の全人材ユニットの平均レベルです。\nこれより低い一般兵のレベルが訓練で上昇します。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void TrainingAverage_MouseLeave(object sender, MouseEventArgs e)
@@ -734,7 +734,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_TrainingUp";
-            helpWindow.SetData("訓練によるターン毎のレベル上昇値です。");
+            helpWindow.SetText("訓練によるターン毎のレベル上昇値です。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void TrainingUp_MouseLeave(object sender, MouseEventArgs e)
@@ -813,7 +813,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_StrategyMenu_BaseLevel";
-            helpWindow.SetData("雇用兵士の底上げレベルです。");
+            helpWindow.SetText("雇用兵士の底上げレベルです。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void BaseLevel_MouseLeave(object sender, MouseEventArgs e)

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml
@@ -41,20 +41,20 @@
             <Image Canvas.Left="6" Canvas.Top="6" Width="32" Height="32" Name="imgFlag" />
             <TextBlock Canvas.Left="45" Canvas.Top="5" FontSize="23" Foreground="White" Text="領地の名前" Name="txtNameSpot" />
 
-            <Button x:Name="btnClose" Width="35" Height="35" Canvas.Left="435" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
+            <Button Name="btnClose" Width="35" Height="35" Canvas.Left="435" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
             <StackPanel Orientation="Horizontal" Canvas.Left="5" Canvas.Top="55">
-                <Button x:Name="btnSelectAll" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="全部"
+                <Button Name="btnSelectAll" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="全部"
                         BorderThickness="2" Focusable="False"
                         PreviewMouseDown="whole_MouseDown"
                         MouseEnter="btnSelectAll_MouseEnter" />
-                <Button x:Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用"
+                <Button Name="btnMercenary" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="雇用"
                         BorderThickness="2" Focusable="False"
                         Click="btnMercenary_Click"
                         PreviewMouseLeftButtonDown="Raise_ZOrder"
                         MouseRightButtonDown="Disable_MouseEvent"
                         MouseEnter="btnMercenary_MouseEnter" />
-                <Button x:Name="btnPolitics" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="内政"
+                <Button Name="btnPolitics" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="内政"
                         BorderThickness="2" Focusable="False"
                         PreviewMouseLeftButtonDown="Raise_ZOrder"
                         MouseRightButtonDown="Disable_MouseEvent" />
@@ -75,14 +75,11 @@
 
 <!--
                     <StackPanel Orientation="Horizontal" Height="66">
-                        <StackPanel>
-                            <Button Height="29" Margin="2" FontSize="17" Content="出撃" />
-                            <ComboBox Width="50" Height="29" Margin="2" FontSize="17">
-                                <ComboBoxItem Content="F"/>
-                                <ComboBoxItem Content="M"/>
-                                <ComboBoxItem Content="B"/>
-                            </ComboBox>
-                        </StackPanel>
+                        <ComboBox Width="52" Height="34" Margin="2" FontSize="20">
+                            <ComboBoxItem Content="F"/>
+                            <ComboBoxItem Content="M"/>
+                            <ComboBoxItem Content="B"/>
+                        </ComboBox>
                         <StackPanel>
                             <Image Height="48" Width="48" Source="./001_Warehouse/001_DefaultGame/040_ChipImage/chipGene003.png" />
                             <TextBlock Height="18" FontSize="16" Foreground="White" TextAlignment="Center" Text="lv199E" />

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -30,10 +30,10 @@ namespace WPF_Successor_001_to_Vahren
 
         // 定数
         // ユニットのタイルサイズをここで調節できます
-        private const int tile_width = 48, tile_height = 66, header_width = 54;
+        private const int tile_width = 48, tile_height = 66, header_width = 56;
         // ドロップ先の強調枠の太さを一括指定します
-        // 太さの違いで判定してるから、必ず drop_select > drop_target にすること。
-        private const int drop_target = 2, drop_select = 4;
+        // 太さの違いで判定してるから、必ず drop_select_width > drop_target_width にすること。
+        private const int drop_target_width = 2, drop_select_width = 4;
 
         // 最初に呼び出した時
         private bool _isControl = false; // 操作可能かどうかの設定
@@ -117,6 +117,12 @@ namespace WPF_Successor_001_to_Vahren
 
             // ウインドウ枠
             SetWindowFrame(mainWindow);
+
+            // 透明から不透明になる
+            var animeOpacity = new DoubleAnimation();
+            animeOpacity.From = 0.1;
+            animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
+            this.BeginAnimation(Grid.OpacityProperty, animeOpacity);
         }
 
         // ウインドウ枠を作る
@@ -243,35 +249,23 @@ namespace WPF_Successor_001_to_Vahren
                     {
                         if (_isControl)
                         {
-                            // 出撃ボタン
-                            Button btnSelect = new Button();
-                            btnSelect.IsEnabled = false; // まだ処理を作ってないのでボタンを無効にする
-                            btnSelect.Name = "btnSelect" + i.ToString();
-                            btnSelect.Height = tile_height / 2 - 4;
-                            btnSelect.Width = header_width - 4;
-                            btnSelect.Margin = new Thickness(2);
-                            btnSelect.Focusable = false;
-                            btnSelect.FontSize = 17;
-                            btnSelect.Content = "出撃";
-                            this.canvasSpotUnit.Children.Add(btnSelect);
-                            Canvas.SetTop(btnSelect, tile_height * i);
-
                             // 陣形コンボボックス
                             ComboBox cmbFormation = new ComboBox();
                             cmbFormation.Name = "cmbFormation" + i.ToString();
-                            cmbFormation.Height = tile_height / 2 - 4;
+                            cmbFormation.Height = header_width - 22;
                             cmbFormation.Width = header_width - 4;
-                            cmbFormation.Margin = new Thickness(2);
+                            cmbFormation.Margin = new Thickness(2, (tile_height - cmbFormation.Height) / 2, 0, 0);
                             cmbFormation.Focusable = false;
 
                             // _010_Enum.Formation の順番に表示するので、Enum数値と Index は同じになる
                             // 項目ごとに背景色を変える
                             Label lblItem0 = new Label();
                             lblItem0.Content = _010_Enum.Formation.F.ToString();
-                            lblItem0.FontSize = 17;
+                            lblItem0.FontSize = 20;
                             lblItem0.HorizontalContentAlignment = HorizontalAlignment.Center;
                             lblItem0.Padding = new Thickness(-5);
                             lblItem0.Width = header_width - 32;
+                            lblItem0.Height = header_width - 28;
                             lblItem0.Background = Brushes.Maroon; // RGB=128,0,0
                             lblItem0.Foreground = Brushes.White;
                             ComboBoxItem cbItem0 = new ComboBoxItem();
@@ -280,10 +274,11 @@ namespace WPF_Successor_001_to_Vahren
 
                             Label lblItem1 = new Label();
                             lblItem1.Content = _010_Enum.Formation.M.ToString();
-                            lblItem1.FontSize = 17;
+                            lblItem1.FontSize = 20;
                             lblItem1.HorizontalContentAlignment = HorizontalAlignment.Center;
                             lblItem1.Padding = new Thickness(-5);
                             lblItem1.Width = header_width - 32;
+                            lblItem1.Height = header_width - 28;
                             lblItem1.Background = Brushes.DarkGreen; // RGB=0,100,0
                             lblItem1.Foreground = Brushes.White;
                             ComboBoxItem cbItem1 = new ComboBoxItem();
@@ -292,10 +287,11 @@ namespace WPF_Successor_001_to_Vahren
 
                             Label lblItem2 = new Label();
                             lblItem2.Content = _010_Enum.Formation.B.ToString();
-                            lblItem2.FontSize = 17;
+                            lblItem2.FontSize = 20;
                             lblItem2.HorizontalContentAlignment = HorizontalAlignment.Center;
                             lblItem2.Padding = new Thickness(-5);
                             lblItem2.Width = header_width - 32;
+                            lblItem2.Height = header_width - 28;
                             lblItem2.Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 160));
                             lblItem2.Foreground = Brushes.White;
                             ComboBoxItem cbItem2 = new ComboBoxItem();
@@ -305,7 +301,7 @@ namespace WPF_Successor_001_to_Vahren
                             cmbFormation.SelectedIndex = (int)itemUnit.Formation.Formation;
                             cmbFormation.SelectionChanged += cmbFormation_SelectionChanged;
                             this.canvasSpotUnit.Children.Add(cmbFormation);
-                            Canvas.SetTop(cmbFormation, tile_height * i + tile_height / 2);
+                            Canvas.SetTop(cmbFormation, tile_height * i);
                         }
                         else
                         {
@@ -325,10 +321,10 @@ namespace WPF_Successor_001_to_Vahren
                             {
                                 lblFormation.Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 160));
                             }
-                            lblFormation.Width = tile_height / 2 - 4;
-                            lblFormation.Height = tile_height / 2 - 4;
+                            lblFormation.Width = header_width - 22;
+                            lblFormation.Height = lblFormation.Width;
                             lblFormation.Margin = new Thickness((header_width - lblFormation.Width) / 2, (tile_height - lblFormation.Height) / 2, 0, 0);
-                            lblFormation.FontSize = 17;
+                            lblFormation.FontSize = 20;
                             lblFormation.Padding = new Thickness(-5);
                             lblFormation.HorizontalContentAlignment = HorizontalAlignment.Center;
                             lblFormation.VerticalContentAlignment = VerticalAlignment.Center;
@@ -396,6 +392,14 @@ namespace WPF_Successor_001_to_Vahren
                         j_max = j;
                     }
                 }
+
+                /*
+                // 部隊の所属領地が正しくセットされてるか調べるデバッグ用
+                if (itemTroop.Spot != classPowerAndCity.ClassSpot)
+                {
+                    MessageBox.Show(i + "番の領地 " + itemTroop.Spot.NameTag);
+                }
+                */
 
                 i++;
             }
@@ -466,19 +470,12 @@ namespace WPF_Successor_001_to_Vahren
             }
             // 戦力値
             {
-                this.txtForce.Text = "戦力 " + this.Name.Replace("dowSpot", String.Empty); // ウインドウ番号を表示する実験用
+                this.txtForce.Text = "戦力 ?";
             }
-            // 部隊駐留数
-            {
-                int spot_capacity = classPowerAndCity.ClassSpot.Capacity;
-                int troop_count = classPowerAndCity.ClassSpot.UnitGroup.Count();
-                this.txtTroopCount.Text = "部隊 " + troop_count.ToString() + "/" + spot_capacity.ToString();
-            }
-            // ユニット
+            // 部隊駐留数とユニット
             {
                 UpdateSpotUnit(mainWindow);
             }
-
 
         }
 
@@ -525,6 +522,10 @@ namespace WPF_Successor_001_to_Vahren
                     return false;
                 }
                 dstSpot = ((ClassPowerAndCity)windowSpot.Tag).ClassSpot;
+            }
+            if (dstSpot == null)
+            {
+                return false;
             }
 
             // 部隊メンバー入れ替え
@@ -719,6 +720,10 @@ namespace WPF_Successor_001_to_Vahren
                 }
                 dstSpot = ((ClassPowerAndCity)windowSpot.Tag).ClassSpot;
             }
+            if (dstSpot == null)
+            {
+                return false;
+            }
 
             // 部隊メンバー追加
             if ((strPart[1] == "Right") && (strPart.Length >= 3))
@@ -750,7 +755,7 @@ namespace WPF_Successor_001_to_Vahren
                 return true;
             }
 
-            // 新規部隊を作成して間に追加
+            // 部隊を間に追加
             if ((strPart[1] == "Top") && (strPart.Length >= 3))
             {
                 // 移動元の部隊
@@ -764,6 +769,7 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     // 移動先領地の指定位置に部隊を挿入する
                     dstSpot.UnitGroup.Insert(dst_troop_id, srcTroop);
+                    srcTroop.Spot = dstSpot;
 
                     // 移動元領地から部隊を取り除く
                     srcSpot.UnitGroup.RemoveAt(troop_id);
@@ -776,6 +782,7 @@ namespace WPF_Successor_001_to_Vahren
 
                     // 移動先領地の指定位置に部隊を挿入する
                     dstSpot.UnitGroup.Insert(dst_troop_id, srcTroop);
+                    srcTroop.Spot = dstSpot;
                 }
 
                 // 表示を更新する
@@ -796,6 +803,7 @@ namespace WPF_Successor_001_to_Vahren
 
                 // 移動先領地の末尾に部隊を追加する
                 dstSpot.UnitGroup.Add(srcTroop);
+                srcTroop.Spot = dstSpot;
 
                 // 移動元領地から部隊を取り除く
                 srcSpot.UnitGroup.RemoveAt(troop_id);
@@ -818,6 +826,7 @@ namespace WPF_Successor_001_to_Vahren
 
                 // 移動先領地の末尾に部隊を追加する
                 dstSpot.UnitGroup.Add(srcTroop);
+                srcTroop.Spot = dstSpot;
 
                 // 移動元領地から部隊を取り除く
                 srcSpot.UnitGroup.RemoveAt(troop_id);
@@ -878,6 +887,10 @@ namespace WPF_Successor_001_to_Vahren
                 }
                 dstSpot = ((ClassPowerAndCity)windowSpot.Tag).ClassSpot;
             }
+            if (dstSpot == null)
+            {
+                return false;
+            }
 
             // 移動先の空きが部隊数よりも少ない場合は、入るだけ移動させる
             int src_troop_count = srcSpot.UnitGroup.Count;
@@ -889,7 +902,7 @@ namespace WPF_Successor_001_to_Vahren
                 move_count = spot_capacity - dst_troop_count;
             }
 
-            // 新規部隊を作成して間に追加
+            // 部隊を間に追加
             if ((strPart[1] == "Top") && (strPart.Length >= 3))
             {
                 // 移動先の指定位置
@@ -902,6 +915,7 @@ namespace WPF_Successor_001_to_Vahren
 
                     // 移動先領地の指定位置に部隊を挿入する
                     dstSpot.UnitGroup.Insert(dst_troop_id + i, srcTroop);
+                    srcTroop.Spot = dstSpot;
 
                     // 移動元領地から先頭の部隊を取り除く
                     srcSpot.UnitGroup.RemoveAt(0);
@@ -928,6 +942,7 @@ namespace WPF_Successor_001_to_Vahren
 
                     // 移動先領地の末尾に部隊を追加する
                     dstSpot.UnitGroup.Add(srcTroop);
+                    srcTroop.Spot = dstSpot;
 
                     // 移動元領地から部隊を取り除く
                     srcSpot.UnitGroup.RemoveAt(0);
@@ -991,7 +1006,7 @@ namespace WPF_Successor_001_to_Vahren
                         Border border = new Border();
                         border.Name = "DropTarget" + this.Name + "_Unit_" + i.ToString() + "_" + j.ToString();
                         border.Background = Brushes.Transparent;
-                        border.BorderThickness = new Thickness(drop_target);
+                        border.BorderThickness = new Thickness(drop_target_width);
                         border.BorderBrush = Brushes.Magenta;
                         border.Width = tile_width - 1;
                         border.Height = tile_height - 1;
@@ -1007,7 +1022,7 @@ namespace WPF_Successor_001_to_Vahren
                     Border border = new Border();
                     border.Name = "DropTarget" + this.Name + "_Right_" + i.ToString();
                     border.Background = Brushes.Transparent;
-                    border.BorderThickness = new Thickness(drop_target);
+                    border.BorderThickness = new Thickness(drop_target_width);
                     border.BorderBrush = Brushes.Magenta;
                     border.Width = tile_width * (member_capacity - j) - 1;
                     border.Height = tile_height - 1;
@@ -1022,7 +1037,7 @@ namespace WPF_Successor_001_to_Vahren
                     Border border = new Border();
                     border.Name = "DropTarget" + this.Name + "_Top_" + i.ToString();
                     border.Background = Brushes.Transparent;
-                    border.BorderThickness = new Thickness(drop_target);
+                    border.BorderThickness = new Thickness(drop_target_width);
                     border.BorderBrush = Brushes.Magenta;
                     border.Width = header_width + tile_width;
                     border.Height = tile_height / 3;
@@ -1039,7 +1054,7 @@ namespace WPF_Successor_001_to_Vahren
                 Border border = new Border();
                 border.Name = "DropTarget" + this.Name + "_Bottom";
                 border.Background = Brushes.Transparent;
-                border.BorderThickness = new Thickness(drop_target);
+                border.BorderThickness = new Thickness(drop_target_width);
                 border.BorderBrush = Brushes.Magenta;
                 border.Width = header_width + tile_width * member_capacity;
                 border.Height = tile_height * (spot_capacity - i);
@@ -1072,7 +1087,7 @@ namespace WPF_Successor_001_to_Vahren
                                 Border border = new Border();
                                 border.Name = "DropTarget" + strTitle + "_Right_" + i.ToString();
                                 border.Background = Brushes.Transparent;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 border.Width = tile_width * (member_capacity - member_count) - 1;
                                 border.Height = tile_height - 1;
@@ -1087,7 +1102,7 @@ namespace WPF_Successor_001_to_Vahren
                                 Border border = new Border();
                                 border.Name = "DropTarget" + strTitle + "_Top_" + i.ToString();
                                 border.Background = Brushes.Transparent;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 border.Width = header_width + tile_width;
                                 border.Height = tile_height / 3;
@@ -1104,7 +1119,7 @@ namespace WPF_Successor_001_to_Vahren
                             Border border = new Border();
                             border.Name = "DropTarget" + strTitle + "_Bottom";
                             border.Background = Brushes.Transparent;
-                            border.BorderThickness = new Thickness(drop_target);
+                            border.BorderThickness = new Thickness(drop_target_width);
                             border.BorderBrush = Brushes.Magenta;
                             border.Width = header_width + tile_width * member_capacity;
                             border.Height = tile_height * (spot_capacity - i);
@@ -1140,7 +1155,7 @@ namespace WPF_Successor_001_to_Vahren
                                 // ワールドマップ上で識別しやすいよう、背景を少し暗くする
                                 SolidColorBrush mySolidColorBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
                                 border.Background = mySolidColorBrush;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 // 領地アイコンの大きさが不明なので、大きめの枠にする
                                 border.Width = 64;
@@ -1194,7 +1209,7 @@ namespace WPF_Successor_001_to_Vahren
                     Border border = new Border();
                     border.Name = "DropTarget" + this.Name + "_Right_" + i.ToString();
                     border.Background = Brushes.Transparent;
-                    border.BorderThickness = new Thickness(drop_target);
+                    border.BorderThickness = new Thickness(drop_target_width);
                     border.BorderBrush = Brushes.Magenta;
                     border.Width = tile_width * (member_capacity - member_count) - 1;
                     border.Height = tile_height - 1;
@@ -1209,7 +1224,7 @@ namespace WPF_Successor_001_to_Vahren
                     Border border = new Border();
                     border.Name = "DropTarget" + this.Name + "_Top_" + i.ToString();
                     border.Background = Brushes.Transparent;
-                    border.BorderThickness = new Thickness(drop_target);
+                    border.BorderThickness = new Thickness(drop_target_width);
                     border.BorderBrush = Brushes.Magenta;
                     border.Width = header_width + tile_width;
                     border.Height = tile_height / 3;
@@ -1226,7 +1241,7 @@ namespace WPF_Successor_001_to_Vahren
                 Border border = new Border();
                 border.Name = "DropTarget" + this.Name + "_Bottom";
                 border.Background = Brushes.Transparent;
-                border.BorderThickness = new Thickness(drop_target);
+                border.BorderThickness = new Thickness(drop_target_width);
                 border.BorderBrush = Brushes.Magenta;
                 border.Width = header_width + tile_width * member_capacity;
                 border.Height = tile_height * (spot_capacity - i);
@@ -1258,7 +1273,7 @@ namespace WPF_Successor_001_to_Vahren
                                 Border border = new Border();
                                 border.Name = "DropTarget" + strTitle + "_Right_" + i.ToString();
                                 border.Background = Brushes.Transparent;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 border.Width = tile_width * (member_capacity - member_count) - 1;
                                 border.Height = tile_height - 1;
@@ -1273,7 +1288,7 @@ namespace WPF_Successor_001_to_Vahren
                                 Border border = new Border();
                                 border.Name = "DropTarget" + strTitle + "_Top_" + i.ToString();
                                 border.Background = Brushes.Transparent;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 border.Width = header_width + tile_width;
                                 border.Height = tile_height / 3;
@@ -1290,7 +1305,7 @@ namespace WPF_Successor_001_to_Vahren
                             Border border = new Border();
                             border.Name = "DropTarget" + strTitle + "_Bottom";
                             border.Background = Brushes.Transparent;
-                            border.BorderThickness = new Thickness(drop_target);
+                            border.BorderThickness = new Thickness(drop_target_width);
                             border.BorderBrush = Brushes.Magenta;
                             border.Width = header_width + tile_width * member_capacity;
                             border.Height = tile_height * (spot_capacity - i);
@@ -1326,7 +1341,7 @@ namespace WPF_Successor_001_to_Vahren
                                 // ワールドマップ上で識別しやすいよう、背景を少し暗くする
                                 SolidColorBrush mySolidColorBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
                                 border.Background = mySolidColorBrush;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 // 親コントロールが Grid なので、標準だと中央配置になる。左上を原点に変えておく。
                                 border.HorizontalAlignment = HorizontalAlignment.Left;
@@ -1401,7 +1416,7 @@ namespace WPF_Successor_001_to_Vahren
                                 Border border = new Border();
                                 border.Name = "DropTarget" + strTitle + "_Top_" + i.ToString();
                                 border.Background = Brushes.Transparent;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 border.Width = header_width + tile_width;
                                 border.Height = tile_height / 3;
@@ -1418,7 +1433,7 @@ namespace WPF_Successor_001_to_Vahren
                             Border border = new Border();
                             border.Name = "DropTarget" + strTitle + "_Bottom";
                             border.Background = Brushes.Transparent;
-                            border.BorderThickness = new Thickness(drop_target);
+                            border.BorderThickness = new Thickness(drop_target_width);
                             border.BorderBrush = Brushes.Magenta;
                             border.Width = header_width + tile_width * member_capacity;
                             border.Height = tile_height * (spot_capacity - i);
@@ -1454,7 +1469,7 @@ namespace WPF_Successor_001_to_Vahren
                                 // ワールドマップ上で識別しやすいよう、背景を少し暗くする
                                 SolidColorBrush mySolidColorBrush = new SolidColorBrush(Color.FromArgb(64, 0, 0, 0));
                                 border.Background = mySolidColorBrush;
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                                 // 親コントロールが Grid なので、標準だと中央配置になる。左上を原点に変えておく。
                                 border.HorizontalAlignment = HorizontalAlignment.Left;
@@ -1494,7 +1509,7 @@ namespace WPF_Successor_001_to_Vahren
                     if (strTarget.StartsWith("DropTarget"))
                     {
                         // 枠が太くなっていれば、選択中の印
-                        if (border.BorderThickness.Left > drop_target)
+                        if (border.BorderThickness.Left > drop_target_width)
                         {
                             // 同じ領地にドロップできるのはユニットか部隊だけなので、全部隊は判定しない
                             strTarget = strTarget.Replace("DropTarget", String.Empty);
@@ -1544,7 +1559,7 @@ namespace WPF_Successor_001_to_Vahren
                                 if (strTarget.StartsWith("DropTarget"))
                                 {
                                     // 枠が太くなっていれば、選択中の印
-                                    if (border.BorderThickness.Left > drop_target)
+                                    if (border.BorderThickness.Left > drop_target_width)
                                     {
                                         strTarget = strTarget.Replace("DropTarget", String.Empty);
                                         if (troop_id >= 0)
@@ -1603,7 +1618,7 @@ namespace WPF_Successor_001_to_Vahren
                             if (strTarget.StartsWith("DropTarget"))
                             {
                                 // 枠が太くなっていれば、選択中の印
-                                if (border.BorderThickness.Left > drop_target)
+                                if (border.BorderThickness.Left > drop_target_width)
                                 {
                                     strTarget = strTarget.Replace("DropTarget", String.Empty);
                                     if (troop_id >= 0)
@@ -1688,9 +1703,9 @@ namespace WPF_Successor_001_to_Vahren
                 borderHit = (Border)hitResult;
                 if (borderHit.Name.StartsWith("DropTarget"))
                 {
-                    if (borderHit.BorderThickness.Left == drop_target)
+                    if (borderHit.BorderThickness.Left == drop_target_width)
                     {
-                        borderHit.BorderThickness = new Thickness(drop_select);
+                        borderHit.BorderThickness = new Thickness(drop_select_width);
                         borderHit.BorderBrush = Brushes.Aqua;
                     }
                 }
@@ -1701,9 +1716,9 @@ namespace WPF_Successor_001_to_Vahren
             {
                 if ((border != borderHit) && (border.Name.StartsWith("DropTarget")))
                 {
-                    if (border.BorderThickness.Left > drop_target)
+                    if (border.BorderThickness.Left > drop_target_width)
                     {
-                        border.BorderThickness = new Thickness(drop_target);
+                        border.BorderThickness = new Thickness(drop_target_width);
                         border.BorderBrush = Brushes.Magenta;
                     }
                 }
@@ -1724,9 +1739,9 @@ namespace WPF_Successor_001_to_Vahren
                         {
                             if ((border != borderHit) && (border.Name.StartsWith("DropTarget")))
                             {
-                                if (border.BorderThickness.Left > drop_target)
+                                if (border.BorderThickness.Left > drop_target_width)
                                 {
-                                    border.BorderThickness = new Thickness(drop_target);
+                                    border.BorderThickness = new Thickness(drop_target_width);
                                     border.BorderBrush = Brushes.Magenta;
                                 }
                             }
@@ -1745,9 +1760,9 @@ namespace WPF_Successor_001_to_Vahren
                     {
                         if ((border != borderHit) && (border.Name.StartsWith("DropTarget")))
                         {
-                            if (border.BorderThickness.Left > drop_target)
+                            if (border.BorderThickness.Left > drop_target_width)
                             {
-                                border.BorderThickness = new Thickness(drop_target);
+                                border.BorderThickness = new Thickness(drop_target_width);
                                 border.BorderBrush = Brushes.Magenta;
                             }
                         }
@@ -1839,8 +1854,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 var thickness = new Thickness();
-                thickness.Left = Math.Truncate(this.Margin.Left + (pt.X - _startPoint.X));
-                thickness.Top = Math.Truncate(this.Margin.Top + (pt.Y - _startPoint.Y));
+                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
+                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
                 this.Margin = thickness;
             }
         }
@@ -1902,7 +1917,7 @@ namespace WPF_Successor_001_to_Vahren
 
                 // メンバーにできるユニットを表示する
                 var helpMember = new UserControl031_HelpMember();
-                helpMember.Name = "HelpMember";
+                helpMember.Name = StringName.windowMember;
                 helpMember.Tag = panelUnit.Tag;
                 helpMember.SetData();
                 mainWindow.canvasUI.Children.Add(helpMember);
@@ -1935,7 +1950,7 @@ namespace WPF_Successor_001_to_Vahren
                 // メンバーのヘルプを閉じる
                 foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl031_HelpMember>())
                 {
-                    if (itemWindow.Name == "HelpMember")
+                    if (itemWindow.Name == StringName.windowMember)
                     {
                         mainWindow.canvasUI.Children.Remove(itemWindow);
                         break;
@@ -2095,8 +2110,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 // ドラッグ量に応じて子コントロールを移動する
-                Canvas.SetLeft(el, Math.Truncate(Canvas.GetLeft(el) + (pt.X - _startPoint.X)));
-                Canvas.SetTop(el, Math.Truncate(Canvas.GetTop(el) + (pt.Y - _startPoint.Y)));
+                Canvas.SetLeft(el, Canvas.GetLeft(el) + (pt.X - _startPoint.X));
+                Canvas.SetTop(el, Canvas.GetTop(el) + (pt.Y - _startPoint.Y));
             }
         }
 
@@ -2248,8 +2263,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 // ドラッグ量に応じて子コントロールを移動する
-                Canvas.SetLeft(el, Math.Truncate(Canvas.GetLeft(el) + (pt.X - _startPoint.X)));
-                Canvas.SetTop(el, Math.Truncate(Canvas.GetTop(el) + (pt.Y - _startPoint.Y)));
+                Canvas.SetLeft(el, Canvas.GetLeft(el) + (pt.X - _startPoint.X));
+                Canvas.SetTop(el, Canvas.GetTop(el) + (pt.Y - _startPoint.Y));
 
                 // 右横の子コントロールも同時に移動させる
                 string unit_name = ((Image)sender).Name;
@@ -2333,7 +2348,7 @@ namespace WPF_Successor_001_to_Vahren
 
                 // 画像をマウス・カーソルの下に置く
                 Point posMouse = e.GetPosition(mainWindow.canvasUI);
-                Point pos = new Point(Math.Truncate(posMouse.X - tile_width / 2), Math.Truncate(posMouse.Y - tile_width / 2));
+                Point pos = new Point(posMouse.X - tile_width / 2, posMouse.Y - tile_width / 2);
                 Canvas.SetLeft(imgDrag, pos.X);
                 Canvas.SetTop(imgDrag, pos.Y);
 
@@ -2425,8 +2440,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 // ドラッグ量に応じて子コントロールを移動する
-                Canvas.SetLeft(el, Math.Truncate(Canvas.GetLeft(el) + (pt.X - _startPoint.X)));
-                Canvas.SetTop(el, Math.Truncate(Canvas.GetTop(el) + (pt.Y - _startPoint.Y)));
+                Canvas.SetLeft(el, Canvas.GetLeft(el) + (pt.X - _startPoint.X));
+                Canvas.SetTop(el, Canvas.GetTop(el) + (pt.Y - _startPoint.Y));
 
                 // 下の子コントロールも同時に移動させる
                 string unit_name = ((Image)sender).Name;
@@ -2590,7 +2605,13 @@ namespace WPF_Successor_001_to_Vahren
                     Left = mainWindow.canvasUI.Width - offsetLeft - windowUnit.MinWidth - ((window_id - 1) % dZ) * dX - ((window_id - 1) / dZ) * dX2,
                     Top = offsetTop + ((window_id - 1) % dZ) * dY
                 };
-                windowUnit.SetData();
+                // プレイヤーがボタンを操作可能かどうか
+                bool bControl = false;
+                if (classCityAndUnit.ClassPowerAndCity.ClassPower.NameTag == mainWindow.ClassGameStatus.SelectionPowerAndCity.ClassPower.NameTag)
+                {
+                    bControl = true;
+                }
+                windowUnit.SetData(bControl);
                 mainWindow.canvasUI.Children.Add(windowUnit);
 
                 // ヒントを閉じた場合は右上から移動させる
@@ -2742,13 +2763,13 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_" + this.Name;
-            helpWindow.SetData(strHelp);
+            helpWindow.SetText(strHelp);
             mainWindow.canvasUI.Children.Add(helpWindow);
 
             // メンバーにできるユニットが表示されてる時はヘルプを隠す
             foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl031_HelpMember>())
             {
-                if (itemWindow.Name == "HelpMember")
+                if (itemWindow.Name == StringName.windowMember)
                 {
                     helpWindow.Visibility = Visibility.Hidden;
                     break;
@@ -2831,7 +2852,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_" + this.Name + "_btnSelectAll";
-            helpWindow.SetData("全てのキャラをドラッグ＆ドロップできるボタンです。\n部隊単位で目的地に入る分だけ移動します。");
+            helpWindow.SetText("全てのキャラをドラッグ＆ドロップできるボタンです。\n部隊単位で目的地に入る分だけ移動します。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void btnSelectAll_MouseLeave(object sender, MouseEventArgs e)
@@ -2910,7 +2931,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_" + this.Name + "_btnMercenary";
-            helpWindow.SetData("領地の雇用ウィンドウを表示します。");
+            helpWindow.SetText("領地の雇用ウィンドウを表示します。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void btnMercenary_MouseLeave(object sender, MouseEventArgs e)

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml
@@ -43,7 +43,7 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock Margin="0,10,35,0" TextAlignment="Center" FontSize="23" Foreground="White" Text="タイトル" Name="txtTitle" />
-            <Button x:Name="btnClose" HorizontalAlignment="Right" VerticalAlignment="Top" Width="35" Height="35" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
+            <Button Name="btnClose" HorizontalAlignment="Right" VerticalAlignment="Top" Width="35" Height="35" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
             <ScrollViewer Grid.Row="1" Name="scrollList" Width="340" Height="490" Margin="5" Focusable="False"
                     VerticalScrollBarVisibility="Auto" CanContentScroll="True" >

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -392,8 +392,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 var thickness = new Thickness();
-                thickness.Left = Math.Truncate(this.Margin.Left + (pt.X - _startPoint.X));
-                thickness.Top = Math.Truncate(this.Margin.Top + (pt.Y - _startPoint.Y));
+                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
+                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
                 this.Margin = thickness;
             }
         }
@@ -425,7 +425,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_" + this.Name;
-            helpWindow.SetData("雇用したユニットは\n１：雇用者の部隊、２：加入可能な他の部隊、３：新隊長となる\nの順で配備されます。");
+            helpWindow.SetText("雇用したユニットは\n１：雇用者の部隊、２：加入可能な他の部隊、３：新隊長となる\nの順で配備されます。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void win_MouseLeave(object sender, MouseEventArgs e)
@@ -604,6 +604,9 @@ namespace WPF_Successor_001_to_Vahren
         // 右ボタンを押して、同じ要素上で離した時だけ反応させる
         private void btnUnit_MouseRightButtonDown(object sender, MouseEventArgs e)
         {
+            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
+            e.Handled = true;
+
             // マウスのキャプチャを開始する
             UIElement el = (UIElement)sender;
             if (el != null)
@@ -615,9 +618,6 @@ namespace WPF_Successor_001_to_Vahren
         // ボタンを右クリックすると部隊の空の分まで雇う
         private void btnUnit_MouseRightButtonUp(object sender, MouseEventArgs e)
         {
-            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
-            e.Handled = true;
-
             // 右ボタンを押した時にイベント・ハンドラーが追加されるので、必ず押してるはず
             UIElement el = (UIElement)sender;
             el.ReleaseMouseCapture();
@@ -796,7 +796,7 @@ namespace WPF_Successor_001_to_Vahren
             // ヘルプを作成する
             var helpWindow = new UserControl030_Help();
             helpWindow.Name = "Help_" + this.Name + "_btnUnit";
-            helpWindow.SetData("左クリックすると一人雇います。\n右クリックすると一部隊単位でまとめて雇えます。");
+            helpWindow.SetText("左クリックすると一人雇います。\n右クリックすると一部隊単位でまとめて雇えます。");
             mainWindow.canvasUI.Children.Add(helpWindow);
         }
         private void btnUnit_MouseLeave(object sender, MouseEventArgs e)

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
@@ -76,8 +76,6 @@ namespace WPF_Successor_001_to_Vahren
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 // ウインドウの大きさを取得する
-                // 自動サイズを整数にするため、UseLayoutRounding="true" にすること！
-                // （整数にするのが無理な場合は、ここで小数点以下を切り上げればいい）
                 double actual_height = this.ActualHeight;
 
                 // マウスの位置によってウインドウの位置を変える

--- a/WPF_Successor_001_to_Vahren/UserControl030_Help.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl030_Help.xaml.cs
@@ -26,7 +26,8 @@ namespace WPF_Successor_001_to_Vahren
             InitializeComponent();
         }
 
-        public void SetData(string txtInput)
+        // ヘルプの文章を指定する
+        public void SetText(string txtInput)
         {
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -257,8 +257,8 @@ namespace WPF_Successor_001_to_Vahren
 
             if (spot_count > 0)
             {
-                target_X = Math.Truncate(target_X / spot_count);
-                target_Y = Math.Truncate(target_Y / spot_count);
+                target_X = target_X / spot_count;
+                target_Y = target_Y / spot_count;
 
                 // 目標にする座標をウインドウ中央にする
                 /*
@@ -300,8 +300,8 @@ namespace WPF_Successor_001_to_Vahren
                             classVec.Y = ge.Y;
                             worldMap.Margin = new Thickness()
                             {
-                                Left = Math.Truncate(ge.X),
-                                Top = Math.Truncate(ge.Y)
+                                Left = ge.X,
+                                Top = ge.Y
                             };
                         }));
                     });

--- a/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl045_Skill.xaml.cs
@@ -330,8 +330,8 @@ namespace WPF_Successor_001_to_Vahren
                 Point pt = e.GetPosition(el);
 
                 var thickness = new Thickness();
-                thickness.Left = Math.Truncate(this.Margin.Left + (pt.X - _startPoint.X));
-                thickness.Top = Math.Truncate(this.Margin.Top + (pt.Y - _startPoint.Y));
+                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
+                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
                 this.Margin = thickness;
             }
         }

--- a/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl050_Msg.xaml.cs
@@ -95,7 +95,7 @@ namespace WPF_Successor_001_to_Vahren
             }
             this.gridMain.Margin = new Thickness()
             {
-                Left = Math.Truncate(this.Width / 2 - this.gridMain.Width / 2),
+                Left = this.Width / 2 - this.gridMain.Width / 2,
                 Top = this.Height - this.gridMain.Height - offsetTop
             };
             */
@@ -240,14 +240,14 @@ namespace WPF_Successor_001_to_Vahren
             {
                 offsetTop = 0;
             }
-            double newLeft = Math.Truncate(this.Width / 2 - this.gridMain.Width / 2);
+            double newLeft = this.Width / 2 - this.gridMain.Width / 2;
             double newTop = this.Height - this.gridMain.Height - offsetTop;
             // 違う場所にあった場合だけ、アニメーションしながら出現させる
             if ((this.gridMain.Margin.Left != newLeft) || (this.gridMain.Margin.Top != newTop))
             {
                 this.gridMain.Margin = new Thickness()
                 {
-                    Left = Math.Truncate(this.Width / 2 - this.gridMain.Width / 2),
+                    Left = this.Width / 2 - this.gridMain.Width / 2,
                     Top = this.Height - this.gridMain.Height - offsetTop
                 };
 
@@ -265,7 +265,7 @@ namespace WPF_Successor_001_to_Vahren
                 animeMargin.From = new Thickness()
                 {
                     Left = this.gridMain.Margin.Left,
-                    Top = this.gridMain.Margin.Top + Math.Truncate(this.gridMain.Height / 2)
+                    Top = this.gridMain.Margin.Top + this.gridMain.Height / 2
                 };
                 animeMargin.Duration = new Duration(TimeSpan.FromSeconds(0.125));
                 animeMargin.Completed += animePositionBottom_Completed;

--- a/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml
@@ -1,14 +1,14 @@
-﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl045_Skill"
+﻿<UserControl x:Class="WPF_Successor_001_to_Vahren.UserControl065_Sortie"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
-             mc:Ignorable="d" 
-             d:DesignHeight="250" d:DesignWidth="400">
+             mc:Ignorable="d" >
     <Grid UseLayoutRounding="True"
             MouseLeftButtonDown="win_MouseLeftButtonDown"
-            MouseRightButtonDown="btnClose_Click">
+            MouseRightButtonDown="btnClose_Click"
+            MouseEnter="win_MouseEnter" >
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
             <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom" Fill="Black" Opacity="0.5" />
@@ -35,23 +35,30 @@
             <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
         </Grid>
 
-        <Grid Margin="16">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="25"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <StackPanel Margin="40,0" VerticalAlignment="Bottom" Name="panelTitle">
-                <TextBlock Height="25" FontSize="19" Foreground="#c8ffff" Name="txtNameSkill" Text="スキルの名前"/>
-            </StackPanel>
-            <Grid Name="gridSkillIcon" Width="34" Height="35" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
-            <Button Name="btnClose" HorizontalAlignment="Right" VerticalAlignment="Top" Width="35" Height="35" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
-            <TextBlock Grid.Row="1" Margin="5,0" FontSize="19" Foreground="White" Name="txtFunc" Text="（スキルの種類）"/>
-            <TextBlock Grid.Row="2" Margin="5,0" MinHeight="25" FontSize="19" LineHeight="25" Foreground="#ffc800" Name="txtHelp" Text="ヘルプの文章&#xa;シナリオ作者が改行することも可能"/>
+        <Canvas Margin="16" Width="430" Height="700" Background="#008000">
+            <TextBlock Canvas.Left="35" Canvas.Top="5" Width="360" FontSize="20" Foreground="Yellow" TextAlignment="Center" Text="領地へ出撃" Name="txtNameSpot" />
 
-            <TextBlock Grid.Row="3" Margin="5,0" FontSize="19" LineHeight="25" Foreground="White" Name="txtDefault" Text="標準でスキル説明文が自動的に生成される。&#xa;改行もコードで書き込む。"/>
+            <Button Name="btnClose" Width="35" Height="35" Canvas.Left="395" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
-        </Grid>
+            <Button Name="btnSortie" Canvas.Left="10" Canvas.Top="40" Width="85" Height="35" Margin="0,0,5,0" FontSize="20" Content="出撃"
+                    BorderThickness="2" Focusable="False"
+                    Click="btnSortie_Click"
+                    PreviewMouseLeftButtonDown="Raise_ZOrder"
+                    MouseRightButtonDown="Disable_MouseEvent"
+                    MouseEnter="btnSortie_MouseEnter" />
+
+            <Border Canvas.Left="305" Canvas.Top="40" Width="80" Height="35" BorderBrush="White" BorderThickness="1">
+                <TextBlock VerticalAlignment="Center" FontSize="20" Foreground="White" TextAlignment="Center" Text="12/12" Name="txtNumber" />
+            </Border>
+
+            <ScrollViewer Width="420" Height="600" Canvas.Left="5" Canvas.Top="85" Background="#282828" Focusable="False"
+                    HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Visible"
+                    MouseRightButtonDown="Disable_MouseEvent" >
+                <StackPanel Name="panelBaseSpot" />
+            </ScrollViewer>
+
+        </Canvas>
+
     </Grid>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml.cs
@@ -1,0 +1,801 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using WPF_Successor_001_to_Vahren._005_Class;
+
+namespace WPF_Successor_001_to_Vahren
+{
+    /// <summary>
+    /// UserControl065_Sortie.xaml の相互作用ロジック
+    /// </summary>
+    public partial class UserControl065_Sortie : UserControl
+    {
+        public UserControl065_Sortie()
+        {
+            InitializeComponent();
+        }
+
+        // 定数
+        // ユニットのタイルサイズをここで調節できます
+        private const int tile_width = 48;
+
+        // 最初に呼び出した時
+        public void SetData()
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // 最前面に配置する
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ((listWindow != null) && (listWindow.Any()))
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
+            }
+
+            // 出撃先は Name から取得する
+            string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
+            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            if (classSpot == null)
+            {
+                return;
+            }
+
+            // 隣接領地は Tag から取得する
+            List<ClassSpot>? listSpot = (List<ClassSpot>)this.Tag;
+            if (listSpot == null)
+            {
+                return;
+            }
+
+            // 関連するウィンドウを開いてた場合は閉じる（移動や雇用で配置状況が変化するのを防ぐ）
+            for (int i = mainWindow.canvasUI.Children.Count - 1; i >= 0; i += -1)
+            {
+                UIElement Child = mainWindow.canvasUI.Children[i];
+                // 領地ウィンドウを閉じる
+                if (Child is UserControl010_Spot)
+                {
+                    var itemWindow = (UserControl010_Spot)Child;
+                    if (itemWindow.Name.StartsWith("WindowSpot"))
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                    }
+                }
+                // ユニット情報ウィンドウを閉じる
+                else if (Child is UserControl015_Unit)
+                {
+                    var itemWindow = (UserControl015_Unit)Child;
+                    if (itemWindow.Name.StartsWith("WindowUnit"))
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                    }
+                }
+                // 雇用ウィンドウを閉じる
+                else if (Child is UserControl020_Mercenary)
+                {
+                    var itemWindow = (UserControl020_Mercenary)Child;
+                    if (itemWindow.Name.EndsWith("Mercenary"))
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                    }
+                }
+            }
+
+            // 出撃ウィンドウを開いてる間、ワールドマップ上で強調する
+            var worldMap = mainWindow.ClassGameStatus.WorldMap;
+            if (worldMap != null)
+            {
+                // ワールドマップ上での強調を全て解除する
+                worldMap.RemoveSpotMarkAll();
+
+                // 出撃先は赤色
+                worldMap.SpotMarkAnime("circle_Red.png", spotNameTag);
+
+                // 出撃可能な領地は青色
+                foreach (var itemSpot in listSpot)
+                {
+                    worldMap.SpotMark("circle_Blue.png", itemSpot.NameTag);
+                }
+            }
+
+            // 出撃先の名前
+            this.txtNameSpot.Text = classSpot.Name + "へ出撃";
+
+            // 出撃部隊数
+            int war_capacity = mainWindow.ListClassScenarioInfo[mainWindow.NumberScenarioSelection].WarCapacity;
+            this.txtNumber.Text = "0/" + war_capacity.ToString();
+
+            // ボタンの背景
+            {
+                List<string> strings = new List<string>();
+                strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+                strings.Add("006_WindowImage");
+                strings.Add("wnd5.png");
+                string path = System.IO.Path.Combine(strings.ToArray());
+                if (System.IO.File.Exists(path))
+                {
+                    // 画像が存在する時だけ、ボタンの枠と文字色を背景に合わせる
+                    BitmapImage theImage = new BitmapImage(new Uri(path));
+                    ImageBrush myImageBrush = new ImageBrush(theImage);
+                    myImageBrush.Stretch = Stretch.Fill;
+                    this.btnSortie.Background = myImageBrush;
+                    this.btnSortie.Foreground = Brushes.White;
+                    this.btnSortie.BorderBrush = Brushes.Silver;
+                }
+            }
+
+            // ウインドウ枠
+            SetWindowFrame(mainWindow);
+
+            // 画面の中央に配置する
+            this.Margin = new Thickness()
+            {
+                Left = mainWindow.canvasUI.Width / 2 - 300,
+                Top = mainWindow.canvasUI.Height / 2 - 400
+            };
+
+            // 出現時のアニメーション
+            var animeOpacity = new DoubleAnimation();
+            animeOpacity.From = 0.1;
+            animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(0.2));
+            this.BeginAnimation(Grid.OpacityProperty, animeOpacity);
+        }
+
+        // ウインドウ枠を作る
+        private void SetWindowFrame(MainWindow mainWindow)
+        {
+            // ウインドウスキンを読み込む
+            List<string> strings = new List<string>();
+            strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+            strings.Add("006_WindowImage");
+            strings.Add("wnd0.png");
+            string path = System.IO.Path.Combine(strings.ToArray());
+            if (System.IO.File.Exists(path) == false)
+            {
+                // 画像が存在しない場合は、デザイン時のまま（色や透明度は xaml で指定する）
+                return;
+            }
+            var skin_bitmap = new BitmapImage(new Uri(path));
+            Int32Rect rect;
+            ImageBrush myImageBrush;
+
+            // RPGツクールXP (192x128) と VX (128x128) のスキンに対応する
+            if ((skin_bitmap.PixelHeight != 128) || ((skin_bitmap.PixelWidth != 128) && (skin_bitmap.PixelWidth != 192)))
+            {
+                // その他の画像は、そのまま引き延ばして表示する
+                // ブラシ設定によって、タイルしたり、アスペクト比を保ったりすることも可能
+                myImageBrush = new ImageBrush(skin_bitmap);
+                myImageBrush.Stretch = Stretch.Fill;
+                this.rectWindowPlane.Fill = myImageBrush;
+                return;
+            }
+
+            // 不要な背景を表示しない
+            this.rectShadowRight.Visibility = Visibility.Hidden;
+            this.rectShadowBottom.Visibility = Visibility.Hidden;
+
+            // 中央
+            rect = new Int32Rect(0, 0, skin_bitmap.PixelWidth - 64, skin_bitmap.PixelWidth - 64);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Stretch = Stretch.Fill;
+            this.rectWindowPlane.Margin = new Thickness(4, 4, 4, 4);
+            this.rectWindowPlane.Fill = myImageBrush;
+
+            // 左上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 0, 16, 16);
+            this.imgWindowLeftTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 0, 16, 16);
+            this.imgWindowRightTop.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 左下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 48, 16, 16);
+            this.imgWindowLeftBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 右上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 48, 16, 16);
+            this.imgWindowRightBottom.Source = new CroppedBitmap(skin_bitmap, rect);
+
+            // 上
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 0, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowTop.Fill = myImageBrush;
+
+            // 下
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 48, 48, 32, 16);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowBottom.Fill = myImageBrush;
+
+            // 左
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 64, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowLeft.Fill = myImageBrush;
+
+            // 右
+            rect = new Int32Rect(skin_bitmap.PixelWidth - 16, 16, 16, 32);
+            myImageBrush = new ImageBrush(new CroppedBitmap(skin_bitmap, rect));
+            myImageBrush.Viewport = new Rect(0, 0, rect.Width, rect.Height);
+            myImageBrush.ViewportUnits = BrushMappingMode.Absolute;
+            myImageBrush.TileMode = TileMode.Tile;
+            this.rectWindowRight.Fill = myImageBrush;
+        }
+
+        // 出撃登録されたユニットの表示だけを更新する
+        public void UpdateSortieUnit(MainWindow mainWindow)
+        {
+            // 部隊の最大メンバー数
+            int member_capacity = mainWindow.ListClassScenarioInfo[mainWindow.NumberScenarioSelection].MemberCapacity;
+
+            // 画像のディレクトリ
+            List<string> strings = new List<string>();
+            strings.Add(mainWindow.ClassConfigGameTitle.DirectoryGameTitle[mainWindow.NowNumberGameTitle].FullName);
+            strings.Add("040_ChipImage");
+            string pathDirectory = System.IO.Path.Combine(strings.ToArray()) + System.IO.Path.DirectorySeparatorChar;
+
+            // 最初に全て消去する
+            this.panelBaseSpot.Children.Clear();
+
+            string strPreviousNameTag = "\"";
+            foreach (var itemTroop in mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup)
+            {
+                // 部隊のパネル
+                StackPanel panelTroop = new StackPanel();
+                panelTroop.Tag = itemTroop;
+                panelTroop.Orientation = Orientation.Horizontal;
+                panelTroop.Width = tile_width * member_capacity;
+                // 背景が無いとマウスに反応しないので透明にする
+                panelTroop.Background = Brushes.Transparent;
+                // 色を変えるためのイベントを追加する
+                panelTroop.MouseEnter += panel_MouseEnter;
+                panelTroop.MouseLeave += panel_MouseLeave;
+                // 出撃キャンセルするためのイベント
+                panelTroop.MouseRightButtonDown += troop_MouseRightButtonDown;
+
+                // ユニットの画像
+                foreach (var itemUnit in itemTroop.ListClassUnit)
+                {
+                    BitmapImage bitimg1 = new BitmapImage(new Uri(pathDirectory + itemUnit.Image));
+                    Image imgUnit = new Image();
+                    imgUnit.Source = bitimg1;
+                    imgUnit.Width = tile_width;
+                    imgUnit.Height = tile_width;
+                    panelTroop.Children.Add(imgUnit);
+                }
+
+                // 出撃元の領地ごとにまとめて表示する
+                string strBaseName = string.Empty;
+                string strBaseNameTag = string.Empty;
+                var baseSpot = (ClassSpot)itemTroop.Spot;
+                if (baseSpot != null)
+                {
+                    strBaseName = baseSpot.Name;
+                    strBaseNameTag = baseSpot.NameTag;
+                }
+
+                // 同じ領地枠に追加する
+                if (strBaseNameTag == strPreviousNameTag)
+                {
+                    var panelSpot = (StackPanel)LogicalTreeHelper.FindLogicalNode(this.panelBaseSpot, "panelSpot" + strBaseNameTag);
+                    if (panelSpot != null)
+                    {
+                        panelSpot.Children.Add(panelTroop);
+                    }
+                    else
+                    {
+                        // 領地枠が見つからなかった
+                        strPreviousNameTag = "\"";
+                    }
+                }
+                // 領地枠を新規作成する
+                if (strBaseNameTag != strPreviousNameTag)
+                {
+                    strPreviousNameTag = strBaseNameTag;
+
+                    // 領地の外枠
+                    Border borderSpot = new Border();
+                    if (this.panelBaseSpot.Children.Count == 0)
+                    {
+                        // 最初の領地枠だけ上のマージンが無い
+                        borderSpot.Margin = new Thickness(0, 0, 5, 0);
+                    }
+                    else
+                    {
+                        borderSpot.Margin = new Thickness(0, 5, 5, 0);
+                    }
+                    borderSpot.Padding = new Thickness(0, 0, 0, 5);
+                    borderSpot.BorderThickness = new Thickness(2);
+                    borderSpot.BorderBrush = Brushes.White;
+                    this.panelBaseSpot.Children.Add(borderSpot);
+
+                    // 領地のパネル
+                    StackPanel panelSpot = new StackPanel();
+                    panelSpot.Name = "panelSpot" + strBaseNameTag;
+                    panelSpot.Tag = baseSpot;
+                    borderSpot.Child = panelSpot;
+
+                    // 領地の名前
+                    if (strBaseName != string.Empty)
+                    {
+                        TextBlock txtSpotName = new TextBlock();
+                        txtSpotName.Height = 30;
+                        txtSpotName.FontSize = 20;
+                        txtSpotName.Foreground = Brushes.White;
+                        txtSpotName.TextAlignment = TextAlignment.Center;
+                        txtSpotName.Text = strBaseName;
+                        panelSpot.Children.Add(txtSpotName);
+                    }
+
+                    // 名前の下に部隊を追加する
+                    panelSpot.Children.Add(panelTroop);
+                }
+            }
+
+            // 出撃部隊数
+            int war_capacity = mainWindow.ListClassScenarioInfo[mainWindow.NumberScenarioSelection].WarCapacity;
+            this.txtNumber.Text = mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup.Count.ToString() + "/" + war_capacity.ToString();
+        }
+
+
+        private void btnClose_Click(object sender, RoutedEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // 出撃登録済みの部隊情報を初期化する
+            foreach (var itemTroop in mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup)
+            {
+                itemTroop.FlagDisplay = true; // 出撃しないと true なのややこしい
+            }
+            mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup.Clear();
+
+            // 出撃先は Name から取得する
+            string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
+            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            if (classSpot == null)
+            {
+                return;
+            }
+
+            // 隣接領地は Tag から取得する
+            List<ClassSpot>? listSpot = (List<ClassSpot>)this.Tag;
+            if (listSpot == null)
+            {
+                return;
+            }
+
+            // 出撃キャンセルしたら、開いてる出撃選択用領地ウィンドウを全て閉じる
+            for (int i = mainWindow.canvasUI.Children.Count - 1; i >= 0; i += -1)
+            {
+                UIElement Child = mainWindow.canvasUI.Children[i];
+                // 出撃選択用領地ウィンドウを閉じる
+                if (Child is UserControl012_SpotSortie)
+                {
+                    var itemWindow = (UserControl012_SpotSortie)Child;
+                    if (itemWindow.Name.StartsWith(StringName.windowSpotSortie))
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                    }
+                }
+                // ユニット情報ウィンドウを閉じる
+                else if (Child is UserControl015_Unit)
+                {
+                    var itemWindow = (UserControl015_Unit)Child;
+                    if (itemWindow.Name.StartsWith("WindowUnit"))
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                    }
+                }
+            }
+
+            // ワールドマップ上での強調を解除する
+            var worldMap = mainWindow.ClassGameStatus.WorldMap;
+            if (worldMap != null)
+            {
+                worldMap.RemoveSpotMark(spotNameTag);
+                foreach (var itemSpot in listSpot)
+                {
+                    worldMap.RemoveSpotMark(itemSpot.NameTag);
+                }
+            }
+
+            // キャンバスから自身を取り除く
+            mainWindow.canvasUI.Children.Remove(this);
+
+            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
+            e.Handled = true;
+        }
+
+        #region ウインドウ移動
+        private bool _isDrag = false; // 外部に公開する必要なし
+        private Point _startPoint;
+
+        private void win_MouseLeftButtonDown(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                // 最前面に移動させる
+                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+                if ((listWindow != null) && (listWindow.Any()))
+                {
+                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                    Canvas.SetZIndex(this, maxZ + 1);
+                }
+            }
+
+            // ドラッグを開始する
+            UIElement el = (UIElement)sender;
+            if (el != null)
+            {
+                _isDrag = true;
+                _startPoint = e.GetPosition(el);
+                el.CaptureMouse();
+                el.MouseLeftButtonUp += win_MouseLeftButtonUp;
+                el.MouseMove += win_MouseMove;
+            }
+        }
+        private void win_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            // ドラック中なら終了する
+            if (_isDrag == true)
+            {
+                UIElement el = (UIElement)sender;
+                el.ReleaseMouseCapture();
+                el.MouseLeftButtonUp -= win_MouseLeftButtonUp;
+                el.MouseMove -= win_MouseMove;
+                _isDrag = false;
+            }
+        }
+        private void win_MouseMove(object sender, MouseEventArgs e)
+        {
+            // ドラック中
+            if (_isDrag == true)
+            {
+                UIElement el = (UIElement)sender;
+                Point pt = e.GetPosition(el);
+
+                var thickness = new Thickness();
+                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
+                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
+                this.Margin = thickness;
+            }
+        }
+        #endregion
+
+        // ボタン等を右クリックした際に、親コントロールが反応しないようにする
+        private void Disable_MouseEvent(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                // 最前面に移動させる
+                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+                if ((listWindow != null) && (listWindow.Any()))
+                {
+                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                    Canvas.SetZIndex(this, maxZ + 1);
+                }
+            }
+
+            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
+            e.Handled = true;
+        }
+
+        // ボタン等をクリックした際に、UserControlを最前面に移動させる
+        private void Raise_ZOrder(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                // 最前面に移動させる
+                var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+                if ((listWindow != null) && (listWindow.Any()))
+                {
+                    int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                    Canvas.SetZIndex(this, maxZ + 1);
+                }
+            }
+        }
+
+        // マウスカーソルが上に来たらユニットのパネルの色を変える
+        private void panel_MouseEnter(object sender, MouseEventArgs e)
+        {
+            var panel = (StackPanel)sender;
+            // WPFの標準色をどうやって取得するのか知らないので、暗い色にする
+            panel.Background = Brushes.Gray;
+        }
+        private void panel_MouseLeave(object sender, MouseEventArgs e)
+        {
+            var panel = (StackPanel)sender;
+            // 背景を消去するとマウスに反応しなくなるので透明にする
+            panel.Background = Brushes.Transparent;
+        }
+
+        // 部隊単位で出撃キャンセルする
+        private void troop_MouseRightButtonDown(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // ルーティングを処理済みとしてマークする（親コントロールのイベントが発生しなくなる）
+            e.Handled = true;
+
+            // 最前面に移動させる
+            var listWindow = mainWindow.canvasUI.Children.OfType<UIElement>().Where(x => x != this);
+            if ((listWindow != null) && (listWindow.Any()))
+            {
+                int maxZ = listWindow.Select(x => Canvas.GetZIndex(x)).Max();
+                Canvas.SetZIndex(this, maxZ + 1);
+            }
+
+            // 部隊を出撃キャンセルする
+            var itemTroop = (ClassHorizontalUnit)((StackPanel)sender).Tag;
+            mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup.Remove(itemTroop);
+            itemTroop.FlagDisplay = true; // 出撃キャンセルすると true なのはややこしい
+
+            // 出撃元の領地ウィンドウが開いてるか探す
+            if (itemTroop.Spot.NameTag != string.Empty)
+            {
+                string strTitle = StringName.windowSpotSortie + itemTroop.Spot.NameTag;
+                foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl012_SpotSortie>())
+                {
+                    if (itemWindow.Name == strTitle)
+                    {
+                        // 選択部隊の強調枠を取り除く
+                        var listTroop = itemTroop.Spot.UnitGroup;
+                        int troop_id = listTroop.IndexOf(itemTroop);
+                        if (troop_id < 0)
+                        {
+                            break;
+                        }
+                        string strBorderName = "SortieSelect" + troop_id.ToString();
+                        foreach (var border in itemWindow.canvasSpotUnit.Children.OfType<Border>())
+                        {
+                            if (border.Name == strBorderName)
+                            {
+                                itemWindow.canvasSpotUnit.Children.Remove(border);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // 出撃ウィンドウを更新する
+            this.UpdateSortieUnit(mainWindow);
+        }
+
+
+
+        // 領地ウインドウにカーソルを乗せた時
+        private void win_MouseEnter(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // カーソルを離した時のイベントを追加する
+            var cast = (UIElement)sender;
+            cast.MouseLeave += win_MouseLeave;
+
+            // 他のヘルプを全て隠す
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if ((itemHelp.Visibility == Visibility.Visible) && (itemHelp.Name.StartsWith("Help_") == true))
+                {
+                    itemHelp.Visibility = Visibility.Hidden;
+                }
+            }
+
+            // ヘルプを作成する
+            var helpWindow = new UserControl030_Help();
+            helpWindow.Name = "Help_" + this.Name;
+            helpWindow.SetText("領地ウィンドウからユニットを右クリックで出撃させます。\n出撃ユニットを右クリックするとキャンセルできます。\nウィンドウを閉じると全てキャンセルされます。");
+            mainWindow.canvasUI.Children.Add(helpWindow);
+        }
+        private void win_MouseLeave(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // イベントを取り除く
+            var cast = (UIElement)sender;
+            cast.MouseLeave -= win_MouseLeave;
+
+            // 表示中のヘルプを取り除く
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if (itemHelp.Name == "Help_" + this.Name)
+                {
+                    mainWindow.canvasUI.Children.Remove(itemHelp);
+                    break;
+                }
+            }
+
+            // 他のヘルプを隠してた場合は、最前面のヘルプだけ表示する
+            int maxZ = -1, thisZ;
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if ((itemHelp.Visibility == Visibility.Hidden) && (itemHelp.Name.StartsWith("Help_") == true))
+                {
+                    thisZ = Canvas.GetZIndex(itemHelp);
+                    if (maxZ < thisZ)
+                    {
+                        maxZ = thisZ;
+                    }
+                }
+            }
+            if (maxZ >= 0)
+            {
+                foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+                {
+                    if ((itemHelp.Visibility == Visibility.Hidden) && (itemHelp.Name.StartsWith("Help_") == true))
+                    {
+                        if (Canvas.GetZIndex(itemHelp) == maxZ)
+                        {
+                            itemHelp.Visibility = Visibility.Visible;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+
+        // 出撃する
+        private void btnSortie_Click(object sender, RoutedEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // 出撃登録されてなければ終わる
+            if (mainWindow.ClassGameStatus.ClassBattle.SortieUnitGroup.Count == 0)
+            {
+                return;
+            }
+
+            // 出撃先は Name から取得する
+            string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
+            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            if (classSpot == null)
+            {
+                return;
+            }
+
+            // 空の領地なら戦闘無しに占領する
+            if (classSpot.UnitGroup.Count == 0)
+            {
+            
+            
+            
+                MessageBox.Show(classSpot.Name + "は空です");
+            
+            }
+
+            MessageBox.Show(classSpot.Name + "には部隊が存在します");
+
+
+        }
+
+        // 出撃ボタンにカーソルを乗せた時
+        private void btnSortie_MouseEnter(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // カーソルを離した時のイベントを追加する
+            var cast = (UIElement)sender;
+            cast.MouseLeave += btnSortie_MouseLeave;
+
+            // 他のヘルプを全て隠す
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if ((itemHelp.Visibility == Visibility.Visible) && (itemHelp.Name.StartsWith("Help_") == true))
+                {
+                    itemHelp.Visibility = Visibility.Hidden;
+                }
+            }
+
+            // ヘルプを作成する
+            var helpWindow = new UserControl030_Help();
+            helpWindow.Name = "Help_" + this.Name + "_btnSortie";
+            helpWindow.SetText("登録されてるメンバーで出撃します。");
+            mainWindow.canvasUI.Children.Add(helpWindow);
+        }
+        private void btnSortie_MouseLeave(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // イベントを取り除く
+            var cast = (UIElement)sender;
+            cast.MouseLeave -= btnSortie_MouseLeave;
+
+            // 表示中のヘルプを取り除く
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if (itemHelp.Name == "Help_" + this.Name + "_btnSortie")
+                {
+                    mainWindow.canvasUI.Children.Remove(itemHelp);
+                    break;
+                }
+            }
+
+            // 他のヘルプを隠してた場合は、最前面のヘルプだけ表示する
+            int maxZ = -1, thisZ;
+            foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+            {
+                if ((itemHelp.Visibility == Visibility.Hidden) && (itemHelp.Name.StartsWith("Help_") == true))
+                {
+                    thisZ = Canvas.GetZIndex(itemHelp);
+                    if (maxZ < thisZ)
+                    {
+                        maxZ = thisZ;
+                    }
+                }
+            }
+            if (maxZ >= 0)
+            {
+                foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
+                {
+                    if ((itemHelp.Visibility == Visibility.Hidden) && (itemHelp.Name.StartsWith("Help_") == true))
+                    {
+                        if (Canvas.GetZIndex(itemHelp) == maxZ)
+                        {
+                            itemHelp.Visibility = Visibility.Visible;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+
+    }
+}

--- a/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
+++ b/WPF_Successor_001_to_Vahren/WPF_Successor_001_to_Vahren.csproj.user
@@ -4,13 +4,16 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>debug battle</ActiveDebugProfile>
+    <ActiveDebugProfile>WPF_Successor_001_to_Vahren</ActiveDebugProfile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="UserControl010_Spot.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="UserControl011_SpotHint.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="UserControl012_SpotSortie.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Update="UserControl015_Unit.xaml.cs">
@@ -46,6 +49,9 @@
     <Compile Update="UserControl060_WorldMap.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="UserControl065_Sortie.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="Win010_TestBattle.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -64,6 +70,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl011_SpotHint.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl012_SpotSortie.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl015_Unit.xaml">
@@ -97,6 +106,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Update="UserControl060_WorldMap.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="UserControl065_Sortie.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="Win010_TestBattle.xaml">

--- a/WPF_Successor_001_to_Vahren/Win020_Dialog.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Win020_Dialog.xaml.cs
@@ -239,9 +239,8 @@ namespace WPF_Successor_001_to_Vahren
                 newTop = maxTop;
             }
 
-            // 座標を整数にする
-            this.Left = Math.Truncate(newLeft);
-            this.Top = Math.Truncate(newTop);
+            this.Left = newLeft;
+            this.Top = newTop;
         }
         #endregion
 

--- a/WPF_Successor_001_to_Vahren/Win025_Select.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Win025_Select.xaml.cs
@@ -222,9 +222,8 @@ namespace WPF_Successor_001_to_Vahren
                 newTop = maxTop;
             }
 
-            // 座標を整数にする
-            this.Left = Math.Truncate(newLeft);
-            this.Top = Math.Truncate(newTop);
+            this.Left = newLeft;
+            this.Top = newTop;
         }
         #endregion
 

--- a/WPF_Successor_001_to_Vahren/Win030_Choice.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Win030_Choice.xaml.cs
@@ -189,9 +189,8 @@ namespace WPF_Successor_001_to_Vahren
                 newTop = maxTop;
             }
 
-            // 座標を整数にする
-            this.Left = Math.Truncate(newLeft);
-            this.Top = Math.Truncate(newTop);
+            this.Left = newLeft;
+            this.Top = newTop;
         }
         #endregion
 


### PR DESCRIPTION
新しい出撃ウィンドウはまだできてませんが、変更点が多いので先に他のファイルを更新します。

UseLayoutRounding を最上位 Canvas に設定すれば子コントロールの座標が整数になるみたいなので、
canvasTop で指定することにしました。

これにより不要になったので、Math.Truncate で座標を整数にしてた箇所を取り除きました。

ヘルプの文章を指定する関数の名前を SetText に変更しました。

部隊を領地間で移動させた時に、所属領地 ClassHorizontalUnit.Spot を更新するようにしました。

ワールドマップ上の領地の所属勢力を変更するメンバ関数を UserControl060_WorldMap に追加しました。