### PR TITLE
行動済みユニットの表示

### DIFF
--- a/WPF_Successor_001_to_Vahren/005_Class/ClassUnit.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassUnit.cs
@@ -64,6 +64,15 @@ namespace WPF_Successor_001_to_Vahren._005_Class
         }
         #endregion
 
+        #region IsDone
+        private bool _isDone = false;
+        public bool IsDone
+        {
+            get { return _isDone; }
+            set { _isDone = value; }
+        }
+        #endregion
+
         #region NameTag
         private string _nameTag = string.Empty;
         public string NameTag

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -377,9 +377,18 @@ namespace WPF_Successor_001_to_Vahren
                     txtLevel.Name = "txtLevel" + i.ToString() + "_" + j.ToString();
                     txtLevel.Height = tile_height - tile_width;
                     txtLevel.FontSize = 16;
-                    txtLevel.Foreground = Brushes.White;
                     txtLevel.TextAlignment = TextAlignment.Center;
-                    txtLevel.Text = "lv" + itemUnit.Level;
+                    if (itemUnit.IsDone == false)
+                    {
+                        txtLevel.Text = "lv" + itemUnit.Level.ToString();
+                        txtLevel.Foreground = Brushes.White;
+                    }
+                    else
+                    {
+                        // 行動済みなら、レベルの横に「E」が付いて、文字色が黄色になる
+                        txtLevel.Text = "lv" + itemUnit.Level.ToString() + "E";
+                        txtLevel.Foreground = Brushes.Yellow;
+                    }
                     panelUnit.Children.Add(txtLevel);
 
                     this.canvasSpotUnit.Children.Add(panelUnit);

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -563,6 +563,7 @@ namespace WPF_Successor_001_to_Vahren
             // 元データから新しくユニットを作る
             ClassUnit newUnit = baseUnit.DeepCopy();
             newUnit.ID = mainWindow.ClassGameStatus.IDCount;
+            newUnit.IsDone = true;
             mainWindow.ClassGameStatus.SetIDCount();
             if (targetTroop == null)
             {
@@ -718,6 +719,7 @@ namespace WPF_Successor_001_to_Vahren
             // 元データから新しくユニットを作る
             ClassUnit newUnit = baseUnit.DeepCopy();
             newUnit.ID = mainWindow.ClassGameStatus.IDCount;
+            newUnit.IsDone = true;
             mainWindow.ClassGameStatus.SetIDCount();
             if (targetTroop == null)
             {
@@ -745,6 +747,7 @@ namespace WPF_Successor_001_to_Vahren
                 // 元データから新しくユニットを作る
                 newUnit = baseUnit.DeepCopy();
                 newUnit.ID = mainWindow.ClassGameStatus.IDCount;
+                newUnit.IsDone = true;
                 mainWindow.ClassGameStatus.SetIDCount();
 
                 // 部隊の末尾に追加する（新規部隊は既に作成済み）


### PR DESCRIPTION
ユニットが行動済みかどうかを識別する値 IsDone を ClassUnit に追加しました。

雇用直後の新規ユニットは行動済みになるようにしました。
領地ウィンドウで行動済みのマークが付くだけで、行動制限はまだ実装してません。