### PR TITLE
初期値と現在値を別リストにしました

### DIFF
--- a/WPF_Successor_001_to_Vahren/005_Class/ClassGameStatus.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassGameStatus.cs
@@ -84,6 +84,7 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 
         #endregion
 
+        // ファイルから読み込んだオリジナルのデータ
         #region ListSpot
         private List<ClassSpot> _listSpot = new List<ClassSpot>();
         public List<ClassSpot> AllListSpot
@@ -130,6 +131,32 @@ namespace WPF_Successor_001_to_Vahren._005_Class
         {
             get { return _listObject; }
             set { _listObject = value; }
+        }
+        #endregion
+
+        // 元データからシナリオ用にコピーして使うデータ
+        #region NowListSpot
+        private List<ClassSpot> _nowlistSpot = new List<ClassSpot>();
+        public List<ClassSpot> NowListSpot
+        {
+            get { return _nowlistSpot; }
+            set { _nowlistSpot = value; }
+        }
+        #endregion
+        #region NowListPower
+        private List<ClassPower> _nowlistPower = new List<ClassPower>();
+        public List<ClassPower> NowListPower
+        {
+            get { return _nowlistPower; }
+            set { _nowlistPower = value; }
+        }
+        #endregion
+        #region NowListUnit
+        private List<ClassUnit> _nowlistUnit = new List<ClassUnit>();
+        public List<ClassUnit> NowListUnit
+        {
+            get { return _nowlistUnit; }
+            set { _nowlistUnit = value; }
         }
         #endregion
 

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassPower.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassPower.cs
@@ -8,6 +8,20 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 {
     public class ClassPower
     {
+        public ClassPower ShallowCopy()
+        {
+            return (ClassPower)MemberwiseClone();
+        }
+        public ClassPower DeepCopy()
+        {
+            ClassPower cp = ShallowCopy();
+            // 配列など参照型のデータを新規作成して元の値をコピーする
+            cp.ListHome = new List<string>(cp.ListHome);
+            cp.ListMember = new List<string>(cp.ListMember);
+            cp.ListCommonConscription = new List<string>(cp.ListCommonConscription);
+            return cp;
+        }
+
         #region Index
         private int _index;
         public int Index
@@ -109,37 +123,16 @@ namespace WPF_Successor_001_to_Vahren._005_Class
             set { _text = value; }
         }
         #endregion
-        #region ListInitMember
-        /// <summary>
-        /// 開始時の領地。
-        /// </summary>
-        private List<string> _listInitMember = new List<string>();
-        public List<string> ListInitMember
-        {
-            get { return _listInitMember; }
-            set { _listInitMember = value; }
-        }
-        #endregion
         #region ListMember
         /// <summary>
-        /// 現在の領地。
+        /// ClassGameStatus.ListPowerでは開始時の領地。
+        /// ClassGameStatus.NowListPowerでは現在の領地。
         /// </summary>
         private List<string> _listMember = new List<string>();
         public List<string> ListMember
         {
             get { return _listMember; }
             set { _listMember = value; }
-        }
-        #endregion
-        #region ListNowMember
-        /// <summary>
-        /// 現在の領地。
-        /// </summary>
-        private List<string> listNowMember = new List<string>();
-        public List<string> ListNowMember
-        {
-            get { return listNowMember; }
-            set { listNowMember = value; }
         }
         #endregion
         #region Image

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassSpot.cs
@@ -5,6 +5,21 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 {
     public class ClassSpot
     {
+        public ClassSpot ShallowCopy()
+        {
+            return (ClassSpot)MemberwiseClone();
+        }
+        public ClassSpot DeepCopy()
+        {
+            ClassSpot cs = ShallowCopy();
+            // 配列など参照型のデータを新規作成して元の値をコピーする
+            cs.ListMember = new List<(string, int)>(cs.ListMember);
+            cs.ListWanderingMonster = new List<(string, int)>(cs.ListWanderingMonster);
+            cs.ListMonster = new List<(string, int)>(cs.ListMonster);
+            cs.UnitGroup = new List<ClassHorizontalUnit>(cs.UnitGroup);
+            return cs;
+        }
+
         #region Index
         private int _index;
         public int Index
@@ -79,49 +94,31 @@ namespace WPF_Successor_001_to_Vahren._005_Class
 
         // 経済値
         #region Gain
-        private int _gain;
+        private int _gain = 0;
         public int Gain
         {
             get { return _gain; }
             set { _gain = value; }
         }
-        private int _initgain = 0;
-        public int InitGain
-        {
-            get { return _initgain; }
-            set { _initgain = value; }
-        }
         #endregion
 
         // 城壁値
         #region Castle
-        private int _castle;
+        private int _castle = 0;
         public int Castle
         {
             get { return _castle; }
             set { _castle = value; }
         }
-        private int _initcastle = 0;
-        public int InitCastle
-        {
-            get { return _initcastle; }
-            set { _initcastle = value; }
-        }
         #endregion
 
         // 部隊駐留数
         #region Capacity
-        private int _capacity;
+        private int _capacity = 0;
         public int Capacity
         {
             get { return _capacity; }
             set { _capacity = value; }
-        }
-        private int _initcapacity = 0;
-        public int InitCapacity
-        {
-            get { return _initcapacity; }
-            set { _initcapacity = value; }
         }
         #endregion
 

--- a/WPF_Successor_001_to_Vahren/005_Class/ClassUnit.cs
+++ b/WPF_Successor_001_to_Vahren/005_Class/ClassUnit.cs
@@ -18,12 +18,14 @@ namespace WPF_Successor_001_to_Vahren._005_Class
             ClassUnit cu = ShallowCopy();
             if (cu.Formation != null)
             {
-
                 var fo = new ClassFormation();
                 fo.Formation = cu.Formation.Formation;
                 fo.Id = cu.Formation.Id;
                 cu.Formation = fo;
             }
+            // 配列など参照型のデータを新規作成して元の値をコピーする
+            cu.SkillName = new List<string>(cu.SkillName);
+            cu.Skill = new List<ClassSkill>(cu.Skill);
             return cu;
         }
         #region Formation

--- a/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticCommonMethod.cs
+++ b/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticCommonMethod.cs
@@ -971,7 +971,7 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.InitGain = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.Gain = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //Castle
@@ -982,7 +982,7 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.InitCastle = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.Castle = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //Capacity
@@ -993,7 +993,7 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                 var first = CheckMatchElement(match_result);
                 if (first != null)
                 {
-                    classSpot.InitCapacity = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
+                    classSpot.Capacity = Convert.ToInt32(first.Value.Replace(Environment.NewLine, ""));
                 }
             }
             //member
@@ -1607,7 +1607,6 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
                 {
                     throw new Exception();
                 }
-                classPower.ListInitMember = first.Value.Replace(Environment.NewLine, "").Split(",").ToList();
                 classPower.ListMember = first.Value.Replace(Environment.NewLine, "").Split(",").ToList();
             }
             {

--- a/WPF_Successor_001_to_Vahren/030_Evaluator/Evaluator.cs
+++ b/WPF_Successor_001_to_Vahren/030_Evaluator/Evaluator.cs
@@ -139,10 +139,10 @@ namespace WPF_Successor_001_to_Vahren._030_Evaluator
                         var intRe = re.Item1 as IntegerObject;
                         if (intRe == null) return null;
 
-                        var getPo = mainWindow.ClassGameStatus.ListPower.Where(x => x.Index == intRe.Value).FirstOrDefault();
+                        var getPo = mainWindow.ClassGameStatus.NowListPower.Where(x => x.Index == intRe.Value).FirstOrDefault();
                         if (getPo == null) return null;
                         enviroment.Set(systemFunctionLiteral.Parameters[1].Value,
-                                        new IntegerObject(getPo.ListNowMember.Count));
+                                        new IntegerObject(getPo.ListMember.Count));
                     }
                     else if (systemFunctionLiteral.Token.Type == TokenType.YET)
                     {
@@ -174,7 +174,7 @@ namespace WPF_Successor_001_to_Vahren._030_Evaluator
                         int powerIndex = intRe.Value;
                         if (powerIndex == -1) return this.False;
 
-                        var ev = this.ClassGameStatus.ListPower
+                        var ev = this.ClassGameStatus.NowListPower
                                     .Where(x => x.Index == powerIndex)
                                     .FirstOrDefault();
                         if (ev == null)

--- a/WPF_Successor_001_to_Vahren/Page001_Conscription.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Page001_Conscription.xaml.cs
@@ -148,7 +148,7 @@ namespace WPF_Successor_001_to_Vahren
         {
             // 駐在部隊トップバー
             {
-                var count = mainWindow.ClassGameStatus.AllListSpot
+                var count = mainWindow.ClassGameStatus.NowListSpot
                     .Where(x => x.NameTag == targetPowerAndCity.ClassSpot.NameTag)
                     .First()
                     .UnitGroup
@@ -164,7 +164,7 @@ namespace WPF_Successor_001_to_Vahren
                 StackPanel stackPanel = new StackPanel();
                 stackPanel.Orientation = Orientation.Vertical;
                 stackPanel.Name = StringName.stackPanelResidentVertical;
-                var tar = mainWindow.ClassGameStatus.AllListSpot
+                var tar = mainWindow.ClassGameStatus.NowListSpot
                     .Where(x => x.NameTag == targetPowerAndCity.ClassSpot.NameTag)
                     .First();
                 foreach (var item in tar.UnitGroup.Where(x => x.Spot.NameTag == targetPowerAndCity.ClassSpot.NameTag))

--- a/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Page010_SortieMenu.xaml.cs
@@ -379,7 +379,7 @@ namespace WPF_Successor_001_to_Vahren
                 }
 
                 //unitの所属情報を書き換え
-                foreach (var item in mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == selectedItem.NameTag))
+                foreach (var item in mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == selectedItem.NameTag))
                 {
                     foreach (var itemUnitGroup in item.UnitGroup)
                     {

--- a/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
@@ -146,7 +146,7 @@ namespace WPF_Successor_001_to_Vahren
             }
             //顔グラ
             {
-                var ima = mainWindow.ClassGameStatus.ListUnit
+                var ima = mainWindow.ClassGameStatus.NowListUnit
                     .Where(x => x.NameTag == mainWindow.ClassGameStatus.SelectionPowerAndCity.ClassPower.MasterTag)
                     .FirstOrDefault();
                 if (ima != null)
@@ -177,7 +177,7 @@ namespace WPF_Successor_001_to_Vahren
             int talent_count = 0;
             int total_level = 0;
             string powerNameTag = mainWindow.ClassGameStatus.SelectionPowerAndCity.ClassPower.NameTag;
-            var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag == powerNameTag);
+            var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag == powerNameTag);
             foreach (var itemSpot in listSpot)
             {
                 total_gain += itemSpot.Gain;
@@ -340,13 +340,13 @@ namespace WPF_Successor_001_to_Vahren
             // ターン開始時に全ての勢力を同時に訓練する方がいいかも？
             // ヴァーレントゥーガは勢力ごとの手順が終わる際に訓練上昇するので、
             // 後手が訓練前に攻め込む際に、先手は訓練が終わってるから、先手が有利になる。
-            foreach (var itemPower in mainWindow.ClassGameStatus.ListPower)
+            foreach (var itemPower in mainWindow.ClassGameStatus.NowListPower)
             {
                 // まずは勢力の人材の平均レベルを計算する
                 int total_level = 0, average_level = 0;
                 int talent_count = 0;
                 string powerNameTag = itemPower.NameTag;
-                var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag == powerNameTag);
+                var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag == powerNameTag);
                 foreach (var itemSpot in listSpot)
                 {
                     // その領地の部隊
@@ -403,7 +403,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // ターン開始時のイベント前に残存勢力の全てのユニットを未行動に戻す
             // 中立領地を除外するのに、勢力が設定されてない領地を抜き出せばいい？
-            var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag != string.Empty);
+            var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag != string.Empty);
             foreach (var itemSpot in listSpot)
             {
                 // その領地の部隊

--- a/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl010_Spot.xaml.cs
@@ -488,7 +488,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 // 領地リストのインデックスから ClassSpot を取得する
                 int spot_id = Int32.Parse(strPart[1]);
-                dstSpot = mainWindow.ClassGameStatus.AllListSpot[spot_id];
+                dstSpot = mainWindow.ClassGameStatus.NowListSpot[spot_id];
 
                 // 領地ウインドウが開いてるかどうか調べる
                 foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl010_Spot>())
@@ -698,7 +698,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 // 領地リストのインデックスから ClassSpot を取得する
                 int spot_id = Int32.Parse(strPart[1]);
-                dstSpot = mainWindow.ClassGameStatus.AllListSpot[spot_id];
+                dstSpot = mainWindow.ClassGameStatus.NowListSpot[spot_id];
 
                 // 領地ウインドウが開いてるかどうか調べる
                 foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl010_Spot>())
@@ -891,7 +891,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 // 領地リストのインデックスから ClassSpot を取得する
                 int spot_id = Int32.Parse(strPart[1]);
-                dstSpot = mainWindow.ClassGameStatus.AllListSpot[spot_id];
+                dstSpot = mainWindow.ClassGameStatus.NowListSpot[spot_id];
 
                 // 領地ウインドウが開いてるかどうか調べる
                 foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl010_Spot>())
@@ -1180,7 +1180,7 @@ namespace WPF_Successor_001_to_Vahren
                 var worldMap = mainWindow.ClassGameStatus.WorldMap;
                 if (worldMap != null)
                 {
-                    var listSpot = mainWindow.ClassGameStatus.AllListSpot;
+                    var listSpot = mainWindow.ClassGameStatus.NowListSpot;
                     int spot_count = listSpot.Count;
                     for (int spot_id = 0; spot_id < spot_count; spot_id++)
                     {
@@ -1366,7 +1366,7 @@ namespace WPF_Successor_001_to_Vahren
                 var worldMap = mainWindow.ClassGameStatus.WorldMap;
                 if (worldMap != null)
                 {
-                    var listSpot = mainWindow.ClassGameStatus.AllListSpot;
+                    var listSpot = mainWindow.ClassGameStatus.NowListSpot;
                     int spot_count = listSpot.Count;
                     for (int spot_id = 0; spot_id < spot_count; spot_id++)
                     {
@@ -1494,7 +1494,7 @@ namespace WPF_Successor_001_to_Vahren
                 var worldMap = mainWindow.ClassGameStatus.WorldMap;
                 if (worldMap != null)
                 {
-                    var listSpot = mainWindow.ClassGameStatus.AllListSpot;
+                    var listSpot = mainWindow.ClassGameStatus.NowListSpot;
                     int spot_count = listSpot.Count;
                     for (int spot_id = 0; spot_id < spot_count; spot_id++)
                     {

--- a/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl020_Mercenary.xaml.cs
@@ -201,10 +201,7 @@ namespace WPF_Successor_001_to_Vahren
                 }
 
                 // 元にするクラスのデータを取得する
-                ClassUnit? itemBaseUnit = mainWindow.ClassGameStatus
-                    .ListUnit
-                    .Where(x => x.NameTag == itemNameTag)
-                    .FirstOrDefault();
+                ClassUnit? itemBaseUnit = mainWindow.ClassGameStatus.ListUnit.Where(x => x.NameTag == itemNameTag).FirstOrDefault();
                 if (itemBaseUnit == null)
                 {
                     continue;
@@ -578,6 +575,7 @@ namespace WPF_Successor_001_to_Vahren
             newUnit.ID = mainWindow.ClassGameStatus.IDCount;
             newUnit.IsDone = true;
             mainWindow.ClassGameStatus.SetIDCount();
+            mainWindow.ClassGameStatus.NowListUnit.Add(newUnit); // 検索用
             if (targetTroop == null)
             {
                 // 新規に部隊を作って隊長にする
@@ -734,6 +732,7 @@ namespace WPF_Successor_001_to_Vahren
             newUnit.ID = mainWindow.ClassGameStatus.IDCount;
             newUnit.IsDone = true;
             mainWindow.ClassGameStatus.SetIDCount();
+            mainWindow.ClassGameStatus.NowListUnit.Add(newUnit); // 検索用
             if (targetTroop == null)
             {
                 // 新規に部隊を作って隊長にする
@@ -762,6 +761,7 @@ namespace WPF_Successor_001_to_Vahren
                 newUnit.ID = mainWindow.ClassGameStatus.IDCount;
                 newUnit.IsDone = true;
                 mainWindow.ClassGameStatus.SetIDCount();
+                mainWindow.ClassGameStatus.NowListUnit.Add(newUnit); // 検索用
 
                 // 部隊の末尾に追加する（新規部隊は既に作成済み）
                 targetTroop.ListClassUnit.Add(newUnit);

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -229,7 +229,7 @@ namespace WPF_Successor_001_to_Vahren
             double target_X = 0, target_Y = 0;
             int spot_count = 0;
             var classPower = (ClassPower)cast.Tag;
-            foreach (var item in classPower.ListInitMember)
+            foreach (var item in classPower.ListMember)
             {
                 var spot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == item).FirstOrDefault();
                 if (spot != null)

--- a/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
@@ -76,7 +76,7 @@ namespace WPF_Successor_001_to_Vahren
                 List<ClassSpot> spotList = new List<ClassSpot>();
                 foreach (var item in mainWindow.ListClassScenarioInfo[mainWindow.NumberScenarioSelection].DisplayListSpot)
                 {
-                    foreach (var item2 in mainWindow.ClassGameStatus.AllListSpot)
+                    foreach (var item2 in mainWindow.ClassGameStatus.NowListSpot)
                     {
                         if (item == item2.NameTag)
                         {
@@ -166,19 +166,19 @@ namespace WPF_Successor_001_to_Vahren
                     // その都市固有の情報を見る為に、勢力の持つスポットと、シナリオで登場するスポットを比較
                     string flag_path = string.Empty;
                     bool ch = false;
-                    for (int i = 0; i < mainWindow.ClassGameStatus.ListPower.Count; i++)
+                    for (int i = 0; i < mainWindow.ClassGameStatus.NowListPower.Count; i++)
                     {
-                        foreach (var item3 in mainWindow.ClassGameStatus.ListPower[i].ListMember)
+                        foreach (var item3 in mainWindow.ClassGameStatus.NowListPower[i].ListMember)
                         {
                             if (item3 == item.value.NameTag)
                             {
                                 // その都市固有の情報を見る為にも、勢力情報と都市情報を入れる
-                                var classPowerAndCity = new ClassPowerAndCity(mainWindow.ClassGameStatus.ListPower[i], item.value);
+                                var classPowerAndCity = new ClassPowerAndCity(mainWindow.ClassGameStatus.NowListPower[i], item.value);
                                 gridButton.Tag = classPowerAndCity;
                                 //ついでに、スポットの属する勢力名を設定
-                                item.value.PowerNameTag = mainWindow.ClassGameStatus.ListPower[i].NameTag;
+                                item.value.PowerNameTag = mainWindow.ClassGameStatus.NowListPower[i].NameTag;
                                 // 旗画像のパスを取得する
-                                flag_path = mainWindow.ClassGameStatus.ListPower[i].FlagPath;
+                                flag_path = mainWindow.ClassGameStatus.NowListPower[i].FlagPath;
                                 ch = true;
                                 break;
                             }
@@ -241,7 +241,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 return;
             }
-            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var classSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (classSpot == null)
             {
                 return;
@@ -308,7 +308,7 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // 指定された勢力を探す
-            var newPower = mainWindow.ClassGameStatus.ListPower
+            var newPower = mainWindow.ClassGameStatus.NowListPower
                         .Where(x => x.NameTag == powerNameTag)
                         .FirstOrDefault();
             if (newPower == null)
@@ -357,7 +357,7 @@ namespace WPF_Successor_001_to_Vahren
             BitmapImage bitimg1 = new BitmapImage(new Uri(path));
             const int ring_size = 128;
 
-            var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag == powerNameTag);
+            var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag == powerNameTag);
             foreach (var itemSpot in listSpot)
             {
                 // 領地が既に強調されてる場合はとばす
@@ -412,7 +412,7 @@ namespace WPF_Successor_001_to_Vahren
             animeRingSize.AutoReverse = true;
             animeRingSize.RepeatBehavior = RepeatBehavior.Forever;
 
-            var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag == powerNameTag);
+            var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag == powerNameTag);
             foreach (var itemSpot in listSpot)
             {
                 // 領地が既に強調されてる場合はとばす
@@ -460,7 +460,7 @@ namespace WPF_Successor_001_to_Vahren
                 return;
             }
 
-            var listSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.PowerNameTag == powerNameTag);
+            var listSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.PowerNameTag == powerNameTag);
             foreach (var itemSpot in listSpot)
             {
                 var itemImage = (Image)LogicalTreeHelper.FindLogicalNode(this.canvasMap, "PowerMark" + itemSpot.NameTag);
@@ -500,7 +500,7 @@ namespace WPF_Successor_001_to_Vahren
                 return;
             }
 
-            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var classSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (classSpot == null)
             {
                 return;
@@ -550,7 +550,7 @@ namespace WPF_Successor_001_to_Vahren
                 return;
             }
 
-            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var classSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (classSpot == null)
             {
                 return;
@@ -1305,7 +1305,7 @@ namespace WPF_Successor_001_to_Vahren
             List<ClassSpot> classSpots = new List<ClassSpot>();
             foreach (var item in NameRinsetuSpot)
             {
-                var ge = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == item).FirstOrDefault();
+                var ge = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == item).FirstOrDefault();
                 if (ge == null)
                 {
                     continue;

--- a/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl065_Sortie.xaml.cs
@@ -51,7 +51,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // 出撃先は Name から取得する
             string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
-            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var classSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (classSpot == null)
             {
                 return;
@@ -363,7 +363,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // 出撃先は Name から取得する
             string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
-            var classSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var classSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (classSpot == null)
             {
                 return;
@@ -681,7 +681,7 @@ namespace WPF_Successor_001_to_Vahren
 
             // 出撃先は Name から取得する
             string spotNameTag = this.Name.Substring(StringName.windowSortie.Length);
-            var targetSpot = mainWindow.ClassGameStatus.AllListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
+            var targetSpot = mainWindow.ClassGameStatus.NowListSpot.Where(x => x.NameTag == spotNameTag).FirstOrDefault();
             if (targetSpot == null)
             {
                 return;

--- a/WPF_Successor_001_to_Vahren/Win020_Dialog.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Win020_Dialog.xaml.cs
@@ -464,7 +464,7 @@ namespace WPF_Successor_001_to_Vahren
             // ユニットの識別名を指定した場合
             if (strNameTag != string.Empty)
             {
-                var classUnit = mainWindow.ClassGameStatus.ListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
+                var classUnit = mainWindow.ClassGameStatus.NowListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
                 if (classUnit != null)
                 {
                     strFaceFile = classUnit.Face;
@@ -527,7 +527,7 @@ namespace WPF_Successor_001_to_Vahren
             // ユニットの識別名を指定した場合
             if (strNameTag != string.Empty)
             {
-                var classUnit = mainWindow.ClassGameStatus.ListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
+                var classUnit = mainWindow.ClassGameStatus.NowListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
                 if (classUnit != null)
                 {
                     strFaceFile = classUnit.Face;
@@ -590,7 +590,7 @@ namespace WPF_Successor_001_to_Vahren
             // ユニットの識別名を指定した場合
             if (strNameTag != string.Empty)
             {
-                var classUnit = mainWindow.ClassGameStatus.ListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
+                var classUnit = mainWindow.ClassGameStatus.NowListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
                 if (classUnit != null)
                 {
                     strFaceFile = classUnit.Face;

--- a/WPF_Successor_001_to_Vahren/Win025_Select.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/Win025_Select.xaml.cs
@@ -416,7 +416,7 @@ namespace WPF_Successor_001_to_Vahren
             // ユニットの識別名を指定した場合
             if (strNameTag != string.Empty)
             {
-                var classUnit = mainWindow.ClassGameStatus.ListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
+                var classUnit = mainWindow.ClassGameStatus.NowListUnit.Where(x => x.NameTag == strNameTag).FirstOrDefault();
                 if (classUnit != null)
                 {
                     strFaceFile = classUnit.Face;


### PR DESCRIPTION
データファイルから読み込んだオリジナルのデータ AllListSpot, ListPower, ListUnit と、
ゲームプレイ中のシナリオごとのデータを分けました。
それぞれ NowListSpot, NowListPower, NowListUnit に格納されます。

ListUnit は登録されてるユニット・クラスの元データ
NowListUnit は実際にゲーム中のユニットのデータです。
NowListUnit には一般兵など同じ識別名のユニットが存在します。（IDで識別する）
統一したリストを保持することで、現在のユニット情報を検索しやすくなります。
（前はListUnit内の初期値しか検索できなかった。）

NowListSpot にプレイ中の領地データが格納されるので、
将来的にイベントなどで経済値や城壁値が変動しても、元データには影響しません。

勢力の所有領データは ClassPower.ListMember だけにしました。
ClassGameStatus.ListPowerでは開始時の領地
ClassGameStatus.NowListPowerでは現在の領地
という意味になります。

初期値と現在値を別リストで保持してるから、
いつでも開始時の値を参照して、元に戻すことができます。
将来的には、シナリオごとに異なる初期値でプレイすることもできそうです。