### PR TITLE
ワールドマップ拡大縮小時のバグ修正

### DIFF
--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -2436,11 +2436,8 @@ namespace WPF_Successor_001_to_Vahren
             this.canvasMain.Children.Add(worldMap);
 
             // 戦闘前のマップ位置にする
-            worldMap.Margin = new Thickness()
-            {
-                Left = this.ClassGameStatus.Camera.X,
-                Top = this.ClassGameStatus.Camera.Y
-            };
+            Canvas.SetLeft(worldMap, this.ClassGameStatus.Camera.X);
+            Canvas.SetTop(worldMap, this.ClassGameStatus.Camera.Y);
 
             //メッセージ
             MessageBox.Show("戦闘が終了しました。");
@@ -3203,16 +3200,27 @@ namespace WPF_Successor_001_to_Vahren
                 return;
             }
 
+            // 目標にする領地の座標
+            double target_X = this.ClassGameStatus.SelectionCityPoint.X;
+            double target_Y = this.ClassGameStatus.SelectionCityPoint.Y;
+
+            // ワールドマップの表示倍率
+            var tran = worldMap.canvasMap.RenderTransform as ScaleTransform;
+            if (tran != null){
+                double scale = tran.ScaleX;
+                target_X *= scale;
+                target_Y *= scale;
+            }
+
             ClassVec classVec = new ClassVec();
             // 現在の Margin
-            classVec.X = worldMap.Margin.Left;
-            classVec.Y = worldMap.Margin.Top;
+            classVec.X = Canvas.GetLeft(worldMap);
+            classVec.Y = Canvas.GetTop(worldMap);
 
-            // 目標にする領地の座標をウインドウ中央にするための Margin
-            classVec.Target = new Point(
-                this.CanvasMainWidth / 2 - this.ClassGameStatus.SelectionCityPoint.X,
-                this.CanvasMainHeight / 2 - this.ClassGameStatus.SelectionCityPoint.Y
-            );
+            // 目標にする領地の座標をウインドウ中央にするための値
+            target_X = Math.Floor(this.CanvasMainWidth / 2 - target_X);
+            target_Y = Math.Floor(this.CanvasMainHeight / 2 - target_Y);
+            classVec.Target = new Point(target_X, target_Y);
             classVec.Speed = 10;
             classVec.Set();
 
@@ -3232,11 +3240,8 @@ namespace WPF_Successor_001_to_Vahren
                         var ge = classVec.Get(new Point(classVec.X, classVec.Y));
                         classVec.X = ge.X;
                         classVec.Y = ge.Y;
-                        worldMap.Margin = new Thickness()
-                        {
-                            Left = ge.X,
-                            Top = ge.Y
-                        };
+                        Canvas.SetLeft(worldMap, Math.Floor(ge.X));
+                        Canvas.SetTop(worldMap, Math.Floor(ge.Y));
                     }));
                 });
             }

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -3213,7 +3213,7 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             ClassVec classVec = new ClassVec();
-            // 現在の Margin
+            // 現在の値
             classVec.X = Canvas.GetLeft(worldMap);
             classVec.Y = Canvas.GetTop(worldMap);
 

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -245,16 +245,23 @@ namespace WPF_Successor_001_to_Vahren
                 target_X = target_X / spot_count;
                 target_Y = target_Y / spot_count;
 
-                ClassVec classVec = new ClassVec();
-                // 現在の Margin
-                classVec.X = worldMap.Margin.Left;
-                classVec.Y = worldMap.Margin.Top;
+                // ワールドマップの表示倍率
+                var tran = worldMap.canvasMap.RenderTransform as ScaleTransform;
+                if (tran != null){
+                    double scale = tran.ScaleX;
+                    target_X *= scale;
+                    target_Y *= scale;
+                }
 
-                // 目標にする領地の座標をウインドウ中央にするための Margin
-                classVec.Target = new Point(
-                    mainWindow.CanvasMainWidth / 2 - target_X,
-                    mainWindow.CanvasMainHeight / 2 - target_Y
-                );
+                ClassVec classVec = new ClassVec();
+                // 現在の値
+                classVec.X = Canvas.GetLeft(worldMap);
+                classVec.Y = Canvas.GetTop(worldMap);
+
+                // 目標にする領地の座標をウインドウ中央にするための値
+                target_X = Math.Floor(mainWindow.CanvasMainWidth / 2 - target_X);
+                target_Y = Math.Floor(mainWindow.CanvasMainHeight / 2 - target_Y);
+                classVec.Target = new Point(target_X, target_Y);
                 // 既に目標に到達してるなら終わる
                 if ((classVec.Target.X == classVec.X) && (classVec.Target.Y == classVec.Y))
                 {
@@ -279,21 +286,15 @@ namespace WPF_Successor_001_to_Vahren
                             var ge = classVec.Get(new Point(classVec.X, classVec.Y));
                             classVec.X = ge.X;
                             classVec.Y = ge.Y;
-                            worldMap.Margin = new Thickness()
-                            {
-                                Left = ge.X,
-                                Top = ge.Y
-                            };
+                            Canvas.SetLeft(worldMap, Math.Floor(ge.X));
+                            Canvas.SetTop(worldMap, Math.Floor(ge.Y));
                         }));
                     });
                 }
 
                 // 目標にする座標をウインドウ中央にする（移動時に微妙にずれても、最後にここで修正する）
-                worldMap.Margin = new Thickness()
-                {
-                    Top = mainWindow.CanvasMainHeight / 2 - target_Y,
-                    Left = mainWindow.CanvasMainWidth / 2 - target_X
-                };
+                Canvas.SetLeft(worldMap, target_X);
+                Canvas.SetTop(worldMap, target_Y);
             }
         }
 

--- a/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
@@ -41,12 +41,14 @@ namespace WPF_Successor_001_to_Vahren
             this.Width = mainWindow.CanvasMainWidth * 2;
             this.Height = mainWindow.CanvasMainHeight * 2;
             // 最初はマップの中央を画面の中央にする
-            this.Margin = new Thickness()
-            {
-                Left = -(mainWindow.CanvasMainWidth / 2),
-                Top = -(mainWindow.CanvasMainHeight / 2)
-            };
-            mainWindow.ClassGameStatus.Camera = new Point(this.Margin.Left, this.Margin.Top);
+            double posLeft = - mainWindow.CanvasMainWidth / 2;
+            double posTop = - mainWindow.CanvasMainHeight / 2;
+            // Margin を使うと、大きく拡大した時に、正しく表示されなくなる。
+            // +-4000 を超えたぐらいから、位置がずれてくる。WPF ぼバグなのかも？
+            // それで、Canvas.SetLeft を使用してます。
+            Canvas.SetLeft(this, posLeft);
+            Canvas.SetTop(this, posTop);
+            mainWindow.ClassGameStatus.Camera = new Point(posLeft, posTop);
 
             this.canvasMap.Children.Clear();
 
@@ -824,9 +826,10 @@ namespace WPF_Successor_001_to_Vahren
                 }
 
                 // マップ位置の制限がうまくいかない？
-                var thickness = new Thickness();
-                thickness.Left = this.Margin.Left + (pt.X - _startPoint.X) * scale;
+                Canvas.SetLeft(this, Math.Floor(Canvas.GetLeft(this) + (pt.X - _startPoint.X) * scale));
+                Canvas.SetTop(this, Math.Floor(Canvas.GetTop(this) + (pt.Y - _startPoint.Y) * scale));
                 /*
+                var thickness = new Thickness();
                 thickness.Left = this.Margin.Left + (pt.X - _startPoint.X);
                 if (thickness.Left > this.Width / 4)
                 {
@@ -836,9 +839,6 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     thickness.Left = this.Width / 4 - this.Width;
                 }
-                */
-                thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y) * scale;
-                /*
                 thickness.Top = this.Margin.Top + (pt.Y - _startPoint.Y);
                 if (thickness.Top > this.Height / 4)
                 {
@@ -848,8 +848,8 @@ namespace WPF_Successor_001_to_Vahren
                 {
                     thickness.Top = this.Height / 4 - this.Height;
                 }
-                */
                 this.Margin = thickness;
+                */
             }
         }
         #endregion
@@ -1430,7 +1430,7 @@ namespace WPF_Successor_001_to_Vahren
             dialog.ShowDialog();
 
             // 現在のマップ表示位置を記録しておく
-            mainWindow.ClassGameStatus.Camera = new Point(this.Margin.Left, this.Margin.Top);
+            mainWindow.ClassGameStatus.Camera = new Point(Canvas.GetLeft(this), Canvas.GetTop(this));
 
             // 出撃ウィンドウを表示する
             var windowSortie = new UserControl065_Sortie();

--- a/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
@@ -44,8 +44,8 @@ namespace WPF_Successor_001_to_Vahren
             double posLeft = - mainWindow.CanvasMainWidth / 2;
             double posTop = - mainWindow.CanvasMainHeight / 2;
             // Margin を使うと、大きく拡大した時に、正しく表示されなくなる。
-            // +-4000 を超えたぐらいから、位置がずれてくる。WPF ぼバグなのかも？
-            // それで、Canvas.SetLeft を使用してます。
+            // +-4000 を超えたぐらいから、位置がずれてくる。WPF のバグなのかも？
+            // それで、Canvas.SetLeft と SetTop を使用してます。
             Canvas.SetLeft(this, posLeft);
             Canvas.SetTop(this, posTop);
             mainWindow.ClassGameStatus.Camera = new Point(posLeft, posTop);


### PR DESCRIPTION
ワールドマップを拡大した時、たまにマップが消えるバグを修正しました。
理由は謎ですが、座標を整数にすれば常に表示されるみたい。
UseLayoutRounding="True" における小数点以下の扱いが怪しい。

マップを拡大縮小していても、勢力を選択した際に
マップ位置が正しく目的地まで移動するようにしました。

まだ問題点が二つ残ってますが、後でまた考えます。
縮尺に応じてマップの位置を制限できない。（マップが画面の外に出ると操作できない）
拡大縮小の中心点が画面中央じゃない。（マップ位置も同時に変更すべき）