### PR TITLE
勢力選択画面でもユニット詳細を表示

### DIFF
--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml
@@ -44,11 +44,12 @@
             <Button Name="btnClose" Width="35" Height="35" Canvas.Left="525" Padding="0,-6,0,0" FontSize="30" Focusable="False" Click="btnClose_Click">×</Button>
 
             <StackPanel Canvas.Left="80" Canvas.Top="5" Width="400">
-                <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center"
-                        MouseEnter="panelNameUnit_MouseEnter" >
-                    <TextBlock FontSize="23" Foreground="White" Text="ユニットの名前" Name="txtNameUnit" />
-                    <TextBlock Margin="0,2" FontSize="20" Foreground="#C8FFC8" Text="（種族名）" Name="txtRace" />
-                </StackPanel>
+                <Grid Background="Transparent" MouseEnter="gridName_MouseEnter">
+                    <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center">
+                        <TextBlock FontSize="23" Foreground="White" Text="ユニットの名前" Name="txtNameUnit" />
+                        <TextBlock Margin="0,2" FontSize="20" Foreground="#C8FFC8" Text="（種族名）" Name="txtRace" />
+                    </StackPanel>
+                </Grid>
                 <StackPanel Orientation="Horizontal" Height="35" HorizontalAlignment="Center">
                     <TextBlock FontSize="20" Foreground="White" Text="レベルとクラス名" Name="txtLevelClass" />
                     <TextBlock FontSize="20" Text="（性別）" Name="txtSex" />

--- a/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl015_Unit.xaml.cs
@@ -1047,7 +1047,7 @@ namespace WPF_Successor_001_to_Vahren
         }
 
         // ユニットの名前パネルにカーソルを乗せた時
-        private void panelNameUnit_MouseEnter(object sender, MouseEventArgs e)
+        private void gridName_MouseEnter(object sender, MouseEventArgs e)
         {
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
@@ -1073,8 +1073,8 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // カーソルを離した時のイベントを追加する
-            var cast = (StackPanel)sender;
-            cast.MouseLeave += panelNameUnit_MouseLeave;
+            var cast = (Grid)sender;
+            cast.MouseLeave += gridName_MouseLeave;
 
             // ハイライトで強調する（文字色が白色なので、あまり白くすると読めなくなる）
             cast.Background = new SolidColorBrush(Color.FromArgb(48, 255, 255, 255));
@@ -1089,7 +1089,7 @@ namespace WPF_Successor_001_to_Vahren
                 mainWindow.canvasUI.Children.Add(itemWindow);
             }
         }
-        private void panelNameUnit_MouseLeave(object sender, MouseEventArgs e)
+        private void gridName_MouseLeave(object sender, MouseEventArgs e)
         {
             var mainWindow = (MainWindow)Application.Current.MainWindow;
             if (mainWindow == null)
@@ -1098,11 +1098,11 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // イベントを取り除く
-            var cast = (StackPanel)sender;
-            cast.MouseLeave -= btnSkill_MouseLeave;
+            var cast = (Grid)sender;
+            cast.MouseLeave -= gridName_MouseLeave;
 
-            // ハイライトを解除する（背景を取り除く）
-            cast.Background = null;
+            // ハイライトを解除する（背景を透明にする）
+            cast.Background = Brushes.Transparent;
 
             // ユニットの説明文を取り除く
             foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl026_DetailUnit>())

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             d:DesignWidth="542" d:DesignHeight="200"
-             MinWidth="542" >
+             d:DesignWidth="542" d:DesignHeight="200">
     <Grid IsHitTestVisible="False" UseLayoutRounding="True">
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
@@ -34,7 +33,7 @@
             <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
         </Grid>
 
-        <Grid Margin="16" Width="510">
+        <Grid Margin="16">
             <Grid.RowDefinitions>
                 <RowDefinition Height="50"/>
                 <RowDefinition Height="Auto"/>
@@ -42,9 +41,9 @@
             <TextBlock Margin="5" FontSize="23" Foreground="White" Name="txtNameSpot" Text="領地の名前"/>
             <Image HorizontalAlignment="Right" Margin="0,0,5,0" Height="32" Width="32" Name="imgSpot" />
 
-            <TextBlock Grid.Row="1" Margin="5" FontSize="20" Foreground="White" Name="txtDetail"
+            <TextBlock Grid.Row="1" Margin="5" MinWidth="400" MaxWidth="500" FontSize="20" Foreground="White" Name="txtDetail"
                     TextWrapping="Wrap" LineHeight="35"
-                    Text="spot構造体のtext要素です。長い文章は自動的に改行されます。"/>
+                    Text="spot構造体のtext要素です。長い文章は自動的に改行されます。&#10;横幅500でヴァーレントゥーガと同程度の文字数"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
@@ -76,6 +76,7 @@ namespace WPF_Successor_001_to_Vahren
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 // ウインドウの大きさを取得する
+                double actual_width = this.ActualWidth;
                 double actual_height = this.ActualHeight;
 
                 // マウスの位置によってウインドウの位置を変える
@@ -94,7 +95,7 @@ namespace WPF_Successor_001_to_Vahren
                     // 画面の右下隅に配置する
                     this.Margin = new Thickness()
                     {
-                        Left = mainWindow.canvasUI.Width - offsetLeft - this.MinWidth,
+                        Left = mainWindow.canvasUI.Width - offsetLeft - actual_width,
                         Top = mainWindow.canvasUI.Height - offsetTop - actual_height
                     };
                 }

--- a/WPF_Successor_001_to_Vahren/UserControl026_DetailUnit.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl026_DetailUnit.xaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             d:DesignWidth="842" d:DesignHeight="250"
-             MinWidth="842" >
+             d:DesignWidth="842" d:DesignHeight="250">
     <Grid IsHitTestVisible="False" UseLayoutRounding="True">
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
@@ -34,7 +33,7 @@
             <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom" />
         </Grid>
 
-        <Grid Margin="16" Width="810">
+        <Grid Margin="16">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -48,9 +47,9 @@
                 <Image Height="96" Name="imgFace" />
             </Border>
 
-            <TextBlock Grid.Row="1" Margin="5" FontSize="20" Foreground="White" Name="txtDetail"
+            <TextBlock Grid.Row="1" Margin="5" MinWidth="500" MaxWidth="800" FontSize="20" Foreground="White" Name="txtDetail"
                     TextWrapping="Wrap" LineHeight="35"
-                    Text="unitのdetail要素です。長い文章は自動的に改行されます。"/>
+                    Text="unitのdetail要素です。長い文章は自動的に改行されます。&#10;横幅800でヴァーレントゥーガと同程度の文字数"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/WPF_Successor_001_to_Vahren/UserControl026_DetailUnit.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl026_DetailUnit.xaml.cs
@@ -96,6 +96,7 @@ namespace WPF_Successor_001_to_Vahren
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 // ウインドウの大きさを取得する
+                double actual_width = this.ActualWidth;
                 double actual_height = this.ActualHeight;
 
                 // マウスの位置によってウインドウの位置を変える
@@ -114,7 +115,7 @@ namespace WPF_Successor_001_to_Vahren
                     // 画面の右下隅に配置する
                     this.Margin = new Thickness()
                     {
-                        Left = mainWindow.canvasUI.Width - offsetLeft - this.MinWidth,
+                        Left = mainWindow.canvasUI.Width - offsetLeft - actual_width,
                         Top = mainWindow.canvasUI.Height - offsetTop - actual_height
                     };
                 }

--- a/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml
@@ -142,7 +142,7 @@
 
             <Canvas Grid.Row="1" Grid.Column="1">
                 <Image Canvas.Left="5" Canvas.Top="15" Height="32" Width="32" Name="imgFlag"/>
-                <Grid Canvas.Left="45" Height="60"
+                <Grid Canvas.Left="45" Height="60" Width="430" Background="Transparent"
                         MouseEnter="gridPower_MouseEnter" >
                     <StackPanel Margin="5,0" VerticalAlignment="Center">
                         <TextBlock FontSize="20" Foreground="#ffc800" Text="勢力の説明" Name="txtHelpPower"/>

--- a/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml.cs
@@ -304,11 +304,17 @@ namespace WPF_Successor_001_to_Vahren
                     gridItem.Children.Add(btnUnit);
 
                     StackPanel panelName = new StackPanel();
-                    panelName.Tag = itemUnit;
                     panelName.HorizontalAlignment = HorizontalAlignment.Center;
                     panelName.VerticalAlignment = VerticalAlignment.Center;
-                    Grid.SetColumn(panelName, 1);
-                    gridItem.Children.Add(panelName);
+
+                    Grid gridName = new Grid();
+                    gridName.Tag = itemUnit;
+                    // マウスに反応するように背景を透明にしておく
+                    gridName.Background = Brushes.Transparent;
+                    gridName.MouseEnter += gridName_MouseEnter;
+                    gridName.Children.Add(panelName);
+                    Grid.SetColumn(gridName, 1);
+                    gridItem.Children.Add(gridName);
 
                     // 肩書
                     if (itemUnit.Help != string.Empty)
@@ -327,7 +333,6 @@ namespace WPF_Successor_001_to_Vahren
 
                     // 名前と種族
                     TextBlock txtName = new TextBlock();
-                    txtName.Tag = itemUnit;
                     txtName.Height = 25;
                     txtName.FontSize = 19;
                     txtName.Foreground = Brushes.White;
@@ -742,7 +747,9 @@ namespace WPF_Successor_001_to_Vahren
             cast.MouseLeave -= win_MouseLeave;
 
             // ハイライトを解除する（背景を取り除く）
-            cast.Background = null;
+            //cast.Background = null;
+            // ハイライトを解除する（背景を透明にする）
+            cast.Background = Brushes.Transparent;
 
             // 表示中のヘルプを取り除く
             foreach (var itemHelp in mainWindow.canvasUI.Children.OfType<UserControl030_Help>())
@@ -779,6 +786,70 @@ namespace WPF_Successor_001_to_Vahren
                             break;
                         }
                     }
+                }
+            }
+        }
+
+        // ユニットの名前パネルにカーソルを乗せた時
+        private void gridName_MouseEnter(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            var cast = (Grid)sender;
+            var targetUnit = (ClassUnit)cast.Tag;
+            if (targetUnit == null)
+            {
+                return;
+            }
+
+            // ユニットの説明文が設定されてないなら終わる
+            if (targetUnit.Text == string.Empty)
+            {
+                return;
+            }
+
+            // カーソルを離した時のイベントを追加する
+            cast.MouseLeave += gridName_MouseLeave;
+
+            // ハイライトで強調する（文字色が白色なので、あまり白くすると読めなくなる）
+            cast.Background = new SolidColorBrush(Color.FromArgb(48, 255, 255, 255));
+
+            // ユニットの説明文を表示する
+            if (targetUnit.Text != string.Empty)
+            {
+                var itemWindow = new UserControl026_DetailUnit();
+                itemWindow.Name = StringName.windowDetailUnit;
+                itemWindow.Tag = targetUnit;
+                itemWindow.SetData();
+                mainWindow.canvasUI.Children.Add(itemWindow);
+            }
+        }
+        private void gridName_MouseLeave(object sender, MouseEventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+
+            // イベントを取り除く
+            var cast = (Grid)sender;
+            cast.MouseLeave -= gridName_MouseLeave;
+
+            // ハイライトを解除する（背景を透明にする）
+            cast.Background = Brushes.Transparent;
+
+            // ユニットの説明文を取り除く
+            foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl026_DetailUnit>())
+            {
+                if (itemWindow.Name == StringName.windowDetailUnit)
+                {
+                    itemWindow.Remove();
+                    break;
                 }
             }
         }


### PR DESCRIPTION
勢力選択画面において、人材リストの名前にマウスカーソルを乗せると、
ユニットの詳細説明文を表示するようにしました。
勢力名にマウスカーソルを乗せる際の、反応領域を広くしました。
ヴァーレントゥーガは旗や閉じるボタンにも重なってるけど、
なんとなく変かなと思って、除外してます。

ユニット情報ウィンドウのユニット名にマウスカーソルを乗せる際も、
反応する範囲を広げました。名前の左右にずれていても、反応します。