### PR TITLE
新しいシナリオ選択画面の実験

### DIFF
--- a/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Scenario/AnyNameWillDo.txt
+++ b/WPF_Successor_001_to_Vahren/001_Warehouse/001_DefaultGame/070_Scenario/Info_Scenario/AnyNameWillDo.txt
@@ -22,13 +22,14 @@ NewFormatScenario sc1
 
 	#シナリオ選択画面の右下に出ます。
 	#
-	#.jpg←未対応
-	#.png←未対応
+	#.jpg
+	#.png
 	#.gif
 	#
-	# デフォでは横900,縦500でぴったりになります。
-	#
-	#scenario_image="test_900x500.gif";
+	#ここで指定したファイル名の後ろに連番で他の画像が存在するとスライドショーします。
+	#例えば sc.png に続いて sc1.png, sc2.png, sc3.png, sc4.png があるなら、
+	#sc.png -> sc1.png -> sc2.png -> sc3.png -> sc4.png -> 先頭に戻ってループする。
+	#右パネルにマウスカーソルを乗せるとスライドショーが始まり、離すと停止します。
 	scenario_image="sc.png";
 
 	#
@@ -45,7 +46,7 @@ NewFormatScenario sc1
 	#ヴァーレントゥーガだと help name
 	#という表記になります。
 	help = "前哨戦1";
-	
+
 	#デフォルトで各行の先頭及び後方の空白は取り除かれます。
 	#空白を入れたい場合はスペースを使って下さい。
 	#
@@ -84,6 +85,7 @@ NewFormatScenario sc1
 			spot0009,spot0010,spot0011,
 			s001,spot0099,spot0098";
 
+	#初期勢力
 	power = "sc_a_p_a,sc_a_p_b,sc_a_p_c";
 
 	#全て出す
@@ -166,14 +168,6 @@ NewFormatScenario sc4
 	sortkey = "2";
 	ButtonType = "Internet";
 	internet = "http://lockedroom.uvs.jp/";
-}
-NewFormatScenario sc5
-{
-	scenario_name="メールを送る実験";
-	text="システムに設定されてるメーラーを開きます！";
-	sortkey = "3";
-	ButtonType = "Mail";
-	mail = "mailto:fluffysheepinx@gmail.com";
 }
 
 scenario sc3

--- a/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/MainWindow.xaml.cs
@@ -319,7 +319,7 @@ namespace WPF_Successor_001_to_Vahren
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ScenarioSelectionButton_click(Object sender, EventArgs e)
+        public void ScenarioSelectionButton_click(Object sender, EventArgs e)
         {
             var cast = (ClassScenarioInfo)((Button)sender).Tag;
             if (cast == null)
@@ -330,6 +330,31 @@ namespace WPF_Successor_001_to_Vahren
             switch (cast.ButtonType)
             {
                 case ButtonType.Scenario:
+                    // データが正しいか確かめる
+                    if (cast.World == string.Empty)
+                    {
+                        MessageBox.Show("シナリオにワールドマップが設定されてません。");
+                        return;
+                    }
+                    if (cast.DisplayListSpot.Count == 0)
+                    {
+                        MessageBox.Show("シナリオに領地が設定されてません。");
+                        return;
+                    }
+                    if (cast.InitListPower.Count == 0)
+                    {
+                        MessageBox.Show("シナリオに勢力が設定されてません。");
+                        return;
+                    }
+
+                    // 選択されたシナリオ番号（ListClassScenarioInfoにおけるIndex）を取得する
+                    int indexScenario = this.ClassGameStatus.ListClassScenarioInfo.IndexOf(cast);
+                    if (indexScenario < 0)
+                    {
+                        MessageBox.Show("シナリオが見つかりません。");
+                        return;
+                    }
+                    this.ClassGameStatus.NumberScenarioSelection = indexScenario;
                     break;
                 case ButtonType.Mail:
                     {
@@ -2234,13 +2259,12 @@ namespace WPF_Successor_001_to_Vahren
                 SetListClassMapBattle(this.NowNumberGameTitle);
             }
 
-            /*
             // シナリオ選択ウィンドウを開く（canvasUIではなくcanvasMainに追加する）
             var itemWindow = new UserControl070_Scenario();
             itemWindow.SetData();
             this.canvasMain.Children.Add(itemWindow);
             return; // 実験中なのでここで終わる。
-            */
+            // ちゃんと動くなら、下のコードを削除して、不要な関数を掃除すること。
 
             // 左上作る
             {

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -147,7 +147,20 @@ namespace WPF_Successor_001_to_Vahren
             this.panelList.Children.Clear();
             int item_count = 0;
 
-            foreach (var itemPower in mainWindow.ClassGameStatus.ListPower)
+            // 現シナリオに登場する初期勢力を抽出する
+            List<ClassPower> powerList = new List<ClassPower>();
+            foreach (var item in mainWindow.ClassGameStatus.ListClassScenarioInfo[mainWindow.ClassGameStatus.NumberScenarioSelection].InitListPower)
+            {
+                foreach (var item2 in mainWindow.ClassGameStatus.NowListPower)
+                {
+                    if (item == item2.NameTag)
+                    {
+                        powerList.Add(item2);
+                        break;
+                    }
+                }
+            }
+            foreach (var itemPower in powerList)
             {
 
                 StackPanel panelItem = new StackPanel();

--- a/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl041_PowerStart.xaml
@@ -36,10 +36,14 @@
             <Image Grid.Column="2" Name="imgWindowRightTop" />
             <Rectangle Grid.Row="1" Name="rectWindowLeft" />
 
-            <Canvas Grid.Row="1" Grid.Column="1">
-                <TextBlock Canvas.Top="5" Width="430" TextAlignment="Center" FontSize="20" Foreground="#c8c8ff" Text="勢力の人材" Name="txtTitle" />
-                <ScrollViewer Canvas.Left="0" Canvas.Top="45" Name="scrollList" Width="430" Height="605"
-                        Focusable="False" VerticalScrollBarVisibility="Visible" >
+            <Grid Grid.Row="1" Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="50"/>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <TextBlock FontSize="20" Margin="0,5" Foreground="#c8c8ff" TextAlignment="Center" Text="勢力の人材" Name="txtTitle" />
+                <ScrollViewer Grid.Row="1" Name="scrollList" Focusable="False"
+                        VerticalScrollBarVisibility="Auto" >
                     <StackPanel Name="panelList">
 
 <!--
@@ -111,7 +115,7 @@
 
                     </StackPanel>
                 </ScrollViewer>
-            </Canvas>
+            </Grid>
 
             <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight" />
             <Image Grid.Row="2" Name="imgWindowLeftBottom" />
@@ -177,7 +181,7 @@
                 </StackPanel>
 
                 <ScrollViewer Canvas.Top="245" Width="520" Height="350" Name="scrollDetail"
-                        Focusable="False" VerticalScrollBarVisibility="Visible">
+                        Focusable="False" VerticalScrollBarVisibility="Auto">
                     <TextBlock Margin="5,0" FontSize="20" Foreground="White" Name="txtDetail"
                             TextWrapping="Wrap" LineHeight="35"
                             Text="power構造体のtext要素です。長い文章は自動的に改行されます。"/>

--- a/WPF_Successor_001_to_Vahren/UserControl070_Scenario.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl070_Scenario.xaml
@@ -43,12 +43,12 @@
 
                 <Grid Grid.Row="1" Grid.Column="1">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="45"/>
+                        <RowDefinition Height="50"/>
                         <RowDefinition />
                     </Grid.RowDefinitions>
-                    <TextBlock Margin="0,5" FontSize="20" Foreground="#c8c8ff" TextAlignment="Center" Text="シナリオ選択" Name="txtTitle" />
+                    <TextBlock FontSize="20" Margin="0,5" Foreground="#c8c8ff" TextAlignment="Center" Text="シナリオ選択" Name="txtTitle" />
                     <ScrollViewer Grid.Row="1" Name="scrollList" Focusable="False"
-                            VerticalScrollBarVisibility="Visible">
+                            VerticalScrollBarVisibility="Auto">
                         <StackPanel Name="panelList">
 <!--
                             <Button Height="50" Margin="5,0,5,0" FontSize="20" Focusable="False" Content="シナリオ１" />
@@ -89,12 +89,12 @@
 
                     <Grid Grid.Row="1" Grid.Column="1">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="45"/>
+                            <RowDefinition Height="50"/>
                             <RowDefinition />
                         </Grid.RowDefinitions>
-                        <TextBlock Margin="0,5" FontSize="20" Foreground="#c8c8ff" TextAlignment="Center" Text="シナリオ選択画面の２つ目のメニュー" Name="txtTitle2" />
+                        <TextBlock FontSize="20" Margin="0,5" Foreground="#c8c8ff" TextAlignment="Center" Text="シナリオ選択画面の２つ目のメニュー" Name="txtTitle2" />
                         <ScrollViewer Grid.Row="1" Name="scrollList2" Focusable="False"
-                                VerticalScrollBarVisibility="Visible">
+                                VerticalScrollBarVisibility="Auto">
                             <StackPanel Name="panelList2">
 <!--
                                 <Button Height="50" Margin="5,0,5,0" FontSize="20" Focusable="False" Content="シナリオ１１" />
@@ -112,49 +112,52 @@
                 </Grid>
             </Grid>
 
-            <Grid Grid.Column="1" Grid.RowSpan="2">
-                <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight2" Fill="Black" Opacity="0.5" />
-                <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom2" Fill="Black" Opacity="0.5" />
-                <Rectangle Margin="0,0,8,8" Name="rectWindowPlane2" Fill="#303030" />
-            </Grid>
-            <Grid Grid.Column="1" Grid.RowSpan="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="16"/>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="16"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="16"/>
-                    <RowDefinition />
-                    <RowDefinition Height="16"/>
-                </Grid.RowDefinitions>
-                <Image Name="imgWindowLeftTop2" />
-                <Rectangle Grid.Column="1" Name="rectWindowTop2" />
-                <Image Grid.Column="2" Name="imgWindowRightTop2" />
-                <Rectangle Grid.Row="1" Name="rectWindowLeft2" />
-
-                <Grid Grid.Row="1" Grid.Column="1">
+            <Grid Grid.Column="1" Grid.RowSpan="2"
+                    MouseEnter="gridRight_MouseEnter"
+                    MouseLeave="gridRight_MouseLeave" >
+                <Grid>
+                    <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight2" Fill="Black" Opacity="0.5" />
+                    <Rectangle Margin="8,0,0,0" Height="8" VerticalAlignment="Bottom" Name="rectShadowBottom2" Fill="Black" Opacity="0.5" />
+                    <Rectangle Margin="0,0,8,8" Name="rectWindowPlane2" Fill="#303030" />
+                </Grid>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="16"/>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="16"/>
+                    </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="45"/>
+                        <RowDefinition Height="16"/>
                         <RowDefinition />
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="16"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Margin="0,5" FontSize="20" Foreground="#ffc800" TextAlignment="Center" Text="シナリオ名" Name="txtNameScenario" />
-                    <ScrollViewer Grid.Row="1" Name="scrollDetail" Focusable="False"
-                            VerticalScrollBarVisibility="Visible" Background="Gray">
-                        <TextBlock Margin="5,0" FontSize="20" Foreground="White" Name="txtDetail"
-                                TextWrapping="Wrap" LineHeight="35"
-                                Text="scenario構造体のtext要素です。長い文章は自動的に改行されます。"/>
-                    </ScrollViewer>
-                    <Image Grid.Row="2" Name="imgScenario" />
+                    <Image Name="imgWindowLeftTop2" />
+                    <Rectangle Grid.Column="1" Name="rectWindowTop2" />
+                    <Image Grid.Column="2" Name="imgWindowRightTop2" />
+                    <Rectangle Grid.Row="1" Name="rectWindowLeft2" />
+
+                    <Grid Grid.Row="1" Grid.Column="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="50"/>
+                            <RowDefinition />
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock FontSize="20" Margin="0,5" Foreground="#ffc800" TextAlignment="Center" Name="txtNameScenario" />
+                        <ScrollViewer Grid.Row="1" Name="scrollDetail" Focusable="False"
+                                VerticalScrollBarVisibility="Auto">
+                            <TextBlock Margin="5,0" FontSize="20" Foreground="White" Name="txtDetail"
+                                    TextWrapping="Wrap" LineHeight="35"/>
+                        </ScrollViewer>
+                        <Image Grid.Row="2" Name="imgScenario" />
+                    </Grid>
+
+                    <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight2" />
+                    <Image Grid.Row="2" Name="imgWindowLeftBottom2" />
+                    <Rectangle Grid.Row="2" Grid.Column="1" Name="rectWindowBottom2" />
+                    <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom2" />
                 </Grid>
 
-                <Rectangle Grid.Row="1" Grid.Column="2" Name="rectWindowRight2" />
-                <Image Grid.Row="2" Name="imgWindowLeftBottom2" />
-                <Rectangle Grid.Row="2" Grid.Column="1" Name="rectWindowBottom2" />
-                <Image Grid.Row="2" Grid.Column="2" Name="imgWindowRightBottom2" />
             </Grid>
-
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
新しいシナリオ選択画面を表示するようにしてみました。
前のコードはまだ残ってるので、新しいのがちゃんと動くなら、
将来的に不要なコードや関数は掃除しないといけません。

シナリオ選択画面と勢力選択画面のリストの垂直スクロールバーを
必要な時だけ表示するように変更してみました。
少し画面の見た目がすっきりするかもしれません。