### PR TITLE
勢力ヒントの改善

### DIFF
--- a/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticStraregyAI.cs
+++ b/WPF_Successor_001_to_Vahren/006_ClassStatic/ClassStaticStraregyAI.cs
@@ -49,34 +49,6 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
         {
             if (classGameStatus == null) return false;
 
-            // この処理はCOM手順の最後に行うこと（プレイヤーと同じく手順終了時にお金が増減するはず）
-            /*
-            //お金増やす
-            {
-                var listSpotMoney = classGameStatus.NowListSpot
-                                .Where(x => x.PowerNameTag == classPower.NameTag);
-                int countMoney = 0;
-                int addMoney = 0; // 維持費と財政値による増減
-                foreach (var itemSpot in listSpotMoney)
-                {
-                    countMoney += itemSpot.Gain;
-                    foreach (var itemTroop in itemSpot.UnitGroup)
-                    {
-                        foreach (var itemUnit in itemTroop.ListClassUnit)
-                        {
-                            // 維持費の分だけ減らして、財政値の分だけ増やす
-                            addMoney -= itemUnit.Cost;
-                            addMoney += itemUnit.Finance;
-                        }
-                    }
-                }
-                countMoney *= (int)(classGameStatus.ClassContext.GainPer * 0.01);
-                countMoney += addMoney;
-
-                classPower.Money += countMoney;
-            }
-            */
-
             ////状態によって隣国へ攻め入る
             ///状態をチェック
             switch (classPower.Fix)
@@ -937,14 +909,13 @@ namespace WPF_Successor_001_to_Vahren._006_ClassStatic
             }));
         }
 
-        // 戦闘終了後に、徴兵など次ターンの準備する
-        // この処理はまだ作ってない
-        /*
-        public static void AfterBattle(ClassGameStatus classGameStatus, ClassPower classPower, MainWindow mainWindow)
+        // 戦闘終了後に徴兵・再配置・別の戦闘などを行う
+        // COM勢力の戦闘処理に続ける場合は true を返すこと
+        public static bool AfterBattle(ClassGameStatus classGameStatus, ClassPower classPower, MainWindow mainWindow)
         {
-        
+            // 今は何もしないで終わる
+            return false;
         }
-        */
 
     }
 }

--- a/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
@@ -313,12 +313,14 @@ namespace WPF_Successor_001_to_Vahren
         #region COM思考関係
 
         //ターン終了ボタンを押下する⇒btnTurnEnd_Clickイベント実行
-        //1.turn_SelectAI
-        //2.turn_StartAI
-        //3.turn_BattleAI
-        //4.turn_WaitAI
-        //5.turn_FinishAI
-        //6.turn_StartTurn
+        //1.turn_SelectAI : AI思考する勢力を選ぶ
+        //2.turn_StartAI  : AI思考を開始する
+        //3.turn_BattleAI : AI戦闘を開始する
+        //4.turn_WaitAI   : AI戦闘の終了を待つ
+        //5.turn_ResumeAI : AI思考を再開する
+        //6.turn_FinishAI : AI思考を終了する ⇒1に戻ってループする
+        //全ての勢力のAI思考が終われば
+        //7.turn_StartTurn : 次のターンの開始処理
         //基本はこの流れで進行する
 
         // ターン経過処理用（アクセスしやすいよう MainWindow の public にしてもいいかも？）
@@ -334,10 +336,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 if (itemWindow.Name == StringName.windowPowerHint)
                 {
-                    if (_nowPower != null)
-                    {
-                        itemWindow.SetPower(_nowPower, false);
-                    }
+                    itemWindow.SetPower(_nowPower, false);
                     itemWindow.SetPos();
                     itemWindow.SetText(strStatus);
                     boolFound = true;
@@ -348,10 +347,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 var itemWindow = new UserControl042_PowerHint();
                 itemWindow.Name = StringName.windowPowerHint;
-                if (_nowPower != null)
-                {
-                    itemWindow.SetPower(_nowPower, false);
-                }
+                itemWindow.SetPower(_nowPower, false);
                 itemWindow.SetPos();
                 itemWindow.SetText(strStatus);
                 mainWindow.canvasUI.Children.Add(itemWindow);
@@ -455,16 +451,12 @@ namespace WPF_Successor_001_to_Vahren
             _timerTurn.Tick -= new EventHandler(turn_StartAI);
             _timerTurn.Stop();
 
-            if (_nowPower == null)
+            bool boolBattle = false;
+            if (_nowPower != null)
             {
-                ShowProgress(mainWindow, "手順の終了処理・・・");
-                _timerTurn.Tick += new EventHandler(turn_FinishAI);
-                _timerTurn.Start();
-                return;
+                // AI思考を実行する
+                boolBattle = ClassStaticStraregyAI.ThinkingEasy(mainWindow.ClassGameStatus, _nowPower, mainWindow);
             }
-
-            // AI思考を実行する
-            bool boolBattle = ClassStaticStraregyAI.ThinkingEasy(mainWindow.ClassGameStatus, _nowPower, mainWindow);
             if (boolBattle)
             {
                 ShowProgress(mainWindow, "戦闘開始・・・");
@@ -531,11 +523,50 @@ namespace WPF_Successor_001_to_Vahren
             // 戦闘してなければ、終了処理を行う
             _timerTurn.Tick -= new EventHandler(turn_WaitAI);
 
-            // 戦闘終了後に、徴兵など次ターンの準備する？
-            // その場合は、もう一つステップを増やすこと
-            ShowProgress(mainWindow, "手順の終了処理・・・");
-            _timerTurn.Tick += new EventHandler(turn_FinishAI);
+            // 戦闘終了後にAI思考を続行する
+            ShowProgress(mainWindow, "戦闘後の処理・・・");
+            _timerTurn.Tick += new EventHandler(turn_ResumeAI);
             _timerTurn.Start();
+        }
+
+        // 戦闘後に AI思考を再開する
+        private void turn_ResumeAI(object? sender, EventArgs e)
+        {
+            var mainWindow = (MainWindow)Application.Current.MainWindow;
+            if (mainWindow == null)
+            {
+                return;
+            }
+            // ゲーム画面が最前面かどうか調べて、背面になってれば何もせずに終わる
+            // バックグラウンドでも動くようにしたい場合は、続行すればいい。
+            if (mainWindow.IsActive == false)
+            {
+                return;
+            }
+
+            // 連続実行されないよう、自身を取り除いて、タイマーを止める
+            _timerTurn.Tick -= new EventHandler(turn_ResumeAI);
+            _timerTurn.Stop();
+
+            bool boolBattle = false;
+            if (_nowPower != null)
+            {
+                // 戦闘終了後に徴兵・再配置・別の戦闘などを行う
+                boolBattle = ClassStaticStraregyAI.AfterBattle(mainWindow.ClassGameStatus, _nowPower, mainWindow);
+            }
+            if (boolBattle)
+            {
+                ShowProgress(mainWindow, "戦闘開始・・・");
+                _timerTurn.Tick += new EventHandler(turn_BattleAI);
+                _timerTurn.Start();
+            }
+            else
+            {
+                // 戦闘しないなら、終了処理を行う
+                ShowProgress(mainWindow, "手順の終了処理・・・");
+                _timerTurn.Tick += new EventHandler(turn_FinishAI);
+                _timerTurn.Start();
+            }
         }
 
         // AI思考を終える
@@ -557,15 +588,11 @@ namespace WPF_Successor_001_to_Vahren
             _timerTurn.Tick -= new EventHandler(turn_FinishAI);
             _timerTurn.Stop();
 
-            if (_nowPower == null)
+            if (_nowPower != null)
             {
-                _timerTurn.Tick += new EventHandler(turn_SelectAI);
-                _timerTurn.Start();
-                return;
+                // COM勢力のターン終了処理（資金の増減や終了時イベントなど）
+                ClassStaticStraregyAI.ThinkingEnd(mainWindow.ClassGameStatus, _nowPower, mainWindow);
             }
-
-            // COM勢力のターン終了処理（資金の増減や終了時イベントなど）
-            ClassStaticStraregyAI.ThinkingEnd(mainWindow.ClassGameStatus, _nowPower, mainWindow);
 
             // 次の勢力へ移る
             _timerTurn.Tick += new EventHandler(turn_SelectAI);

--- a/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl005_StrategyMenu.xaml.cs
@@ -320,7 +320,7 @@ namespace WPF_Successor_001_to_Vahren
         //5.turn_ResumeAI : AI思考を再開する
         //6.turn_FinishAI : AI思考を終了する ⇒1に戻ってループする
         //全ての勢力のAI思考が終われば
-        //7.turn_StartTurn : 次のターンの開始処理
+        // turn_StartTurn : 次のターンの開始処理
         //基本はこの流れで進行する
 
         // ターン経過処理用（アクセスしやすいよう MainWindow の public にしてもいいかも？）

--- a/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl025_DetailSpot.xaml.cs
@@ -28,7 +28,6 @@ namespace WPF_Successor_001_to_Vahren
             InitializeComponent();
         }
 
-
         public void SetData()
         {
             var mainWindow = (MainWindow)Application.Current.MainWindow;
@@ -41,6 +40,23 @@ namespace WPF_Successor_001_to_Vahren
             if (targetSpot == null)
             {
                 return;
+            }
+
+            // 同じウィンドウ（あるいはダミー画像）が既に存在する場合は消す
+            {
+                foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl025_DetailSpot>())
+                {
+                    if (itemWindow.Name == StringName.windowDetailSpot)
+                    {
+                        mainWindow.canvasUI.Children.Remove(itemWindow);
+                        break;
+                    }
+                }
+                var imgDummy = (Image)LogicalTreeHelper.FindLogicalNode(mainWindow.canvasUI, "DummyDetailSpot");
+                if (imgDummy != null)
+                {
+                    mainWindow.canvasUI.Children.Remove(imgDummy);
+                }
             }
 
             // 最前面に配置する
@@ -246,6 +262,7 @@ namespace WPF_Successor_001_to_Vahren
             mainWindow.canvasUI.Children.Add(imgDummy);
 
             // 本体を取り除く
+            this.BeginAnimation(Grid.OpacityProperty, null);
             this.BeginAnimation(Grid.MarginProperty, null);
             mainWindow.canvasUI.Children.Remove(this);
 
@@ -263,7 +280,7 @@ namespace WPF_Successor_001_to_Vahren
             var animeOpacity = new DoubleAnimation();
             animeOpacity.To = 0.1;
             animeOpacity.Duration = new Duration(TimeSpan.FromSeconds(time_span));
-            imgDummy.BeginAnimation(Grid.OpacityProperty, animeOpacity);
+            imgDummy.BeginAnimation(Image.OpacityProperty, animeOpacity);
 
             var animeMargin = new ThicknessAnimation();
             animeMargin.To = new Thickness()
@@ -273,7 +290,7 @@ namespace WPF_Successor_001_to_Vahren
             };
             animeMargin.Duration = new Duration(TimeSpan.FromSeconds(time_span));
             animeMargin.Completed += animeRemoveDetail_Completed;
-            imgDummy.BeginAnimation(Grid.MarginProperty, animeMargin);
+            imgDummy.BeginAnimation(Image.MarginProperty, animeMargin);
         }
         private void animeRemoveDetail_Completed(object? sender, EventArgs e)
         {
@@ -290,8 +307,8 @@ namespace WPF_Successor_001_to_Vahren
             }
 
             // ダミー画像を消す
-            imgDummy.BeginAnimation(Grid.OpacityProperty, null);
-            imgDummy.BeginAnimation(Grid.MarginProperty, null);
+            imgDummy.BeginAnimation(Image.OpacityProperty, null);
+            imgDummy.BeginAnimation(Image.MarginProperty, null);
             mainWindow.canvasUI.Children.Remove(imgDummy);
         }
 

--- a/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl040_PowerSelect.xaml.cs
@@ -341,6 +341,13 @@ namespace WPF_Successor_001_to_Vahren
                     worldMap.PowerMarkAnime("circle_Yellow.png", classPower.NameTag);
                 }
             }
+
+            // 勢力のヒントを表示する
+            var itemWindow = new UserControl042_PowerHint();
+            itemWindow.Name = StringName.windowPowerHint;
+            itemWindow.SetPower(classPower, true);
+            itemWindow.SetPosAnime();
+            mainWindow.canvasUI.Children.Add(itemWindow);
         }
         private void btnPowerSelect_MouseLeave(object sender, MouseEventArgs e)
         {
@@ -368,6 +375,16 @@ namespace WPF_Successor_001_to_Vahren
                 if (worldMap != null)
                 {
                     worldMap.RemovePowerMark(classPower.NameTag);
+                }
+            }
+
+            // 勢力のヒントを閉じる
+            foreach (var itemWindow in mainWindow.canvasUI.Children.OfType<UserControl042_PowerHint>())
+            {
+                if (itemWindow.Name == StringName.windowPowerHint)
+                {
+                    itemWindow.Remove();
+                    break;
                 }
             }
         }

--- a/WPF_Successor_001_to_Vahren/UserControl042_PowerHint.xaml
+++ b/WPF_Successor_001_to_Vahren/UserControl042_PowerHint.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:WPF_Successor_001_to_Vahren"
              mc:Ignorable="d" 
-             Width="432" Height="432">
+             Width="432" Height="382">
     <Grid IsHitTestVisible="False" UseLayoutRounding="True">
         <Grid>
             <Rectangle Margin="0,8" Width="8" HorizontalAlignment="Right" Name="rectShadowRight" Fill="Black" Opacity="0.5" />
@@ -64,9 +64,9 @@
             </StackPanel>
             <TextBlock Canvas.Left="290" Canvas.Top="210" FontSize="19" Foreground="#ffc800" Text="兵レベル +99" Name="txtBaseLevel" />
 
-            <Grid Canvas.Top="250" Width="400" Height="150" Background="Green">
+            <Grid Canvas.Top="250" Width="400" Height="90">
                 <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20" Foreground="White"
-                        TextWrapping="Wrap" LineHeight="30" Name="txtStatus"
+                        TextWrapping="Wrap" LineHeight="30" MaxWidth="390" Name="txtStatus"
                         Text="下部の中央に状態テキスト&#10;改行もできる" />
             </Grid>
 

--- a/WPF_Successor_001_to_Vahren/UserControl042_PowerHint.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl042_PowerHint.xaml.cs
@@ -377,8 +377,7 @@ namespace WPF_Successor_001_to_Vahren
                 Canvas.SetZIndex(this, maxZ + 1);
             }
 
-            // 面倒なので表示する際のアニメーションは省略する
-            // 将来的には追加してもいい、引数でアニメの on/off 指定とか
+            // 画面の左下隅に配置する
             double offsetLeft = 0, offsetTop = 0;
             if (mainWindow.canvasUI.Margin.Left < 0)
             {
@@ -388,7 +387,6 @@ namespace WPF_Successor_001_to_Vahren
             {
                 offsetTop = mainWindow.canvasUI.Margin.Top * -1;
             }
-            // 画面の左下隅に配置する
             this.Margin = new Thickness()
             {
                 Left = offsetLeft,

--- a/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
+++ b/WPF_Successor_001_to_Vahren/UserControl060_WorldMap.xaml.cs
@@ -1117,12 +1117,35 @@ namespace WPF_Successor_001_to_Vahren
 
             // 勢力のヒントを表示する
             // ヴァーレントゥーガだとプレイヤー担当勢力は表示しないけど、どうする？
-            if (classPower != mainWindow.ClassGameStatus.SelectionPowerAndCity.ClassPower)
+            var currentPower = mainWindow.ClassGameStatus.SelectionPowerAndCity.ClassPower;
+            if (classPower != currentPower)
             {
                 var itemWindow = new UserControl042_PowerHint();
                 itemWindow.Name = StringName.windowPowerHint;
                 itemWindow.SetPower(classPower, true);
-                itemWindow.SetPos();
+                if (currentPower.NameTag != string.Empty)
+                {
+                    // 外交関係を調べる
+                    int intDiplo = 50; // 設定が無い場合の標準値を 50 にする
+                    foreach (var item in mainWindow.ClassGameStatus.NowClassDiplomacy.Diplo)
+                    {
+                        if (currentPower.NameTag == item.Item1 && item.Item2 == classPower.NameTag)
+                        {
+                            intDiplo = item.Item3;
+                            continue;
+                        }
+                        if (currentPower.NameTag == item.Item2 && item.Item1 == classPower.NameTag)
+                        {
+                            intDiplo = item.Item3;
+                            continue;
+                        }
+                    }
+                    //itemWindow.SetText("現在の勢力は" + currentPower.Name + "\n対象の勢力は" + classPower.Name + "\n友好度 = " + intDiplo.ToString());
+                    itemWindow.SetText("友好度 = " + intDiplo.ToString());
+                    // 将来的には数値ではなく、「友邦」とか「敵対」のような文字で表現すること。
+                    // 同盟中なら、同盟期間も表示すればいい。
+                }
+                itemWindow.SetPosAnime();
                 mainWindow.canvasUI.Children.Add(itemWindow);
             }
 
@@ -1191,7 +1214,7 @@ namespace WPF_Successor_001_to_Vahren
             {
                 if (itemWindow.Name == StringName.windowPowerHint)
                 {
-                    mainWindow.canvasUI.Children.Remove(itemWindow);
+                    itemWindow.Remove();
                     break;
                 }
             }


### PR DESCRIPTION
勢力選択画面において、右上の勢力名ボタンにマウスカーソルを乗せると、
その勢力の情報が画面左下に表示されるようにしました。
勢力ヒントを表示する時と消す時にエフェクトを付けました。

戦略画面において、ワールドマップ上の旗にマウスカーソルを乗せた際に表示される
勢力ヒントに対象勢力との友好度を表示するようにしました。

戦闘終了後にAI思考を再開して、再度戦闘することができるようにしました。